### PR TITLE
Fixed Command injection in cocoapods-downloader

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -62,7 +62,7 @@ GEM
       public_suffix (~> 4.0)
       typhoeus (~> 1.0)
     cocoapods-deintegrate (1.0.5)
-    cocoapods-downloader (1.5.1)
+    cocoapods-downloader (1.6.3)
     cocoapods-plugins (1.0.0)
       nap
     cocoapods-search (1.0.1)
@@ -275,6 +275,7 @@ GEM
 
 PLATFORMS
   x86_64-darwin-19
+  x86_64-linux
 
 DEPENDENCIES
   cocoapods


### PR DESCRIPTION
## Changes:
The `gojek/clickstream-ios` used cocoapods-downloader 1.6.0, from 1.6.2 and before 1.6.3 are vulnerable to Command Injection via git argument injection. When calling the `Pod::Downloader.preprocess_options` function and using git, both the git and branch parameters are passed to the git ls-remote subcommand in a way that additional flags can be set. The additional flags can be used to perform a command injection.

```js
require 'cocoapods-downloader' options = { :git => '--upload-pack=touch ./HELLO1;', :branch => 'foo'} options = Pod::Downloader.preprocess_options(options) # ls -la
```
 * After Fixed 
```js
      it 'throws when proving an invalid input' do
          options = { :git => '--upload-pack=touch ./HELLO1;', :branch => 'foo' }
          e = lambda { Downloader.preprocess_options(options) }.should.raise DownloaderError
          e.message.should.match /Provided unsafe input/
        end
```
## Operational Impact
CVE-2022-24440
[CWE-74](https://cwe.mitre.org/data/definitions/74.html)
[CWE-88](https://cwe.mitre.org/data/definitions/88.html)
`CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H`