### PR TITLE
Updating podspec for lint passing 

### DIFF
--- a/Clickstream.podspec
+++ b/Clickstream.podspec
@@ -22,44 +22,32 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = '11.0'
   s.swift_version    = '5.0'
 
-  s.pod_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
-  s.user_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
-  
+  s.source_files  = 'Sources/Clickstream/**/*.{h,m,swift}'
+  s.exclude_files = "Example"
+  s.frameworks    = "UIKit", "Foundation", "CoreTelephony"
+  s.dependency    "SwiftProtobuf", "1.10.2"
+  s.dependency    "ReachabilitySwift"
+  s.dependency    "GRDB.swift", "6.7.0"
+  s.dependency    "Starscream", "4.0.4"
   
   s.default_subspec  = 'Core'
 
   s.subspec 'Core' do |core|
-    core.source_files  = 'Sources/**/*.{h,m,swift}'
-    core.exclude_files = "Example"
-    core.frameworks    = "UIKit", "Foundation", "CoreTelephony"
-    core.dependency    "SwiftProtobuf", "1.10.2"
-    core.dependency    "ReachabilitySwift"
-    core.dependency    "GRDB.swift", "6.7.0"
-    core.dependency    "Starscream", "4.0.4"
   end
 
   s.subspec 'Tracker' do |tracker|
     tracker.source_files = 'Sources/**/*.{h,m,swift}'
     tracker.xcconfig =  { 'SWIFT_ACTIVE_COMPILATION_CONDITIONS' => '$(inherited) TRACKER_ENABLED' }
-    tracker.pod_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
-    tracker.user_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
-    tracker.dependency    "Clickstream/Core"
   end
 
   s.subspec 'EventVisualizer' do |eventVisualizer|
     eventVisualizer.source_files = 'Sources/**/*.{h,m,swift}'
     eventVisualizer.xcconfig =  { 'SWIFT_ACTIVE_COMPILATION_CONDITIONS' => '$(inherited) EVENT_VISUALIZER_ENABLED' }
-    eventVisualizer.pod_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
-    eventVisualizer.user_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
-    eventVisualizer.dependency    "Clickstream/Core"
   end
 
   s.subspec 'ETETestSuite' do |eteTestSuite|
     eteTestSuite.source_files = 'Sources/**/*.{h,m,swift}'
     eteTestSuite.xcconfig =  { 'SWIFT_ACTIVE_COMPILATION_CONDITIONS' => '$(inherited) ETE_TEST_SUITE_ENABLED' }
-    eteTestSuite.pod_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
-    eteTestSuite.user_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
-    eteTestSuite.dependency    "Clickstream/Core"
   end
 
 end

--- a/Clickstream.podspec
+++ b/Clickstream.podspec
@@ -37,16 +37,22 @@ Pod::Spec.new do |s|
 
   s.subspec 'Tracker' do |tracker|
     tracker.source_files = 'Sources/**/*.swift'
+    s.exclude_files = "Sources/EventVisualizer/**/*.swift"
+    s.exclude_files = "Sources/ETETestSuite/**/*.swift"
     tracker.xcconfig =  { 'SWIFT_ACTIVE_COMPILATION_CONDITIONS' => '$(inherited) TRACKER_ENABLED' }
   end
 
   s.subspec 'EventVisualizer' do |eventVisualizer|
     eventVisualizer.source_files = 'Sources/**/*.swift'
+    s.exclude_files = "Sources/Tracker/**/*.swift"
+    s.exclude_files = "Sources/ETETestSuite/**/*.swift"
     eventVisualizer.xcconfig =  { 'SWIFT_ACTIVE_COMPILATION_CONDITIONS' => '$(inherited) EVENT_VISUALIZER_ENABLED' }
   end
 
   s.subspec 'ETETestSuite' do |eteTestSuite|
     eteTestSuite.source_files = 'Sources/**/*.swift'
+    s.exclude_files = "Sources/Tracker/**/*.swift"
+    s.exclude_files = "Sources/EventVisualizer/**/*.swift"
     eteTestSuite.xcconfig =  { 'SWIFT_ACTIVE_COMPILATION_CONDITIONS' => '$(inherited) ETE_TEST_SUITE_ENABLED' }
   end
 

--- a/Clickstream.podspec
+++ b/Clickstream.podspec
@@ -22,7 +22,7 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = '11.0'
   s.swift_version    = '5.0'
 
-  s.source_files  = 'Sources/Clickstream/**/*.{h,m,swift}'
+  s.source_files  = 'Sources/Clickstream/**/*.swift'
   s.exclude_files = "Example"
   s.frameworks    = "UIKit", "Foundation", "CoreTelephony"
   s.dependency    "SwiftProtobuf", "1.10.2"
@@ -36,17 +36,17 @@ Pod::Spec.new do |s|
   end
 
   s.subspec 'Tracker' do |tracker|
-    tracker.source_files = 'Sources/**/*.{h,m,swift}'
+    tracker.source_files = 'Sources/**/*.swift'
     tracker.xcconfig =  { 'SWIFT_ACTIVE_COMPILATION_CONDITIONS' => '$(inherited) TRACKER_ENABLED' }
   end
 
   s.subspec 'EventVisualizer' do |eventVisualizer|
-    eventVisualizer.source_files = 'Sources/**/*.{h,m,swift}'
+    eventVisualizer.source_files = 'Sources/**/*.swift'
     eventVisualizer.xcconfig =  { 'SWIFT_ACTIVE_COMPILATION_CONDITIONS' => '$(inherited) EVENT_VISUALIZER_ENABLED' }
   end
 
   s.subspec 'ETETestSuite' do |eteTestSuite|
-    eteTestSuite.source_files = 'Sources/**/*.{h,m,swift}'
+    eteTestSuite.source_files = 'Sources/**/*.swift'
     eteTestSuite.xcconfig =  { 'SWIFT_ACTIVE_COMPILATION_CONDITIONS' => '$(inherited) ETE_TEST_SUITE_ENABLED' }
   end
 

--- a/Clickstream.podspec
+++ b/Clickstream.podspec
@@ -22,35 +22,44 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = '11.0'
   s.swift_version    = '5.0'
 
-  s.source_files  = 'Sources/Clickstream/**/*.swift'
-  s.exclude_files = "Example"
-  s.frameworks    = "UIKit", "Foundation", "CoreTelephony"
+  s.pod_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
+  s.user_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
   
-  s.dependency    "SwiftProtobuf", "1.10.2"
-  s.dependency    "ReachabilitySwift"
-  s.dependency    "GRDB.swift", "6.7.0"
-  s.dependency    "Starscream", "4.0.4"
+  
   s.default_subspec  = 'Core'
 
   s.subspec 'Core' do |core|
+    core.source_files  = 'Sources/**/*.{h,m,swift}'
+    core.exclude_files = "Example"
+    core.frameworks    = "UIKit", "Foundation", "CoreTelephony"
+    core.dependency    "SwiftProtobuf", "1.10.2"
+    core.dependency    "ReachabilitySwift"
+    core.dependency    "GRDB.swift", "6.7.0"
+    core.dependency    "Starscream", "4.0.4"
   end
 
   s.subspec 'Tracker' do |tracker|
-    tracker.source_files = 'Sources/Tracker/**/*.swift'
+    tracker.source_files = 'Sources/**/*.{h,m,swift}'
     tracker.xcconfig =  { 'SWIFT_ACTIVE_COMPILATION_CONDITIONS' => '$(inherited) TRACKER_ENABLED' }
-    tracker.dependency    "Core"
+    tracker.pod_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
+    tracker.user_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
+    tracker.dependency    "Clickstream/Core"
   end
 
   s.subspec 'EventVisualizer' do |eventVisualizer|
-    eventVisualizer.source_files = 'Sources/EventVisualizer/**/*.swift'
+    eventVisualizer.source_files = 'Sources/**/*.{h,m,swift}'
     eventVisualizer.xcconfig =  { 'SWIFT_ACTIVE_COMPILATION_CONDITIONS' => '$(inherited) EVENT_VISUALIZER_ENABLED' }
-    eventVisualizer.dependency    "Core"
+    eventVisualizer.pod_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
+    eventVisualizer.user_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
+    eventVisualizer.dependency    "Clickstream/Core"
   end
 
   s.subspec 'ETETestSuite' do |eteTestSuite|
-    eteTestSuite.source_files = 'Sources/ETETestSuite/**/*.swift'
+    eteTestSuite.source_files = 'Sources/**/*.{h,m,swift}'
     eteTestSuite.xcconfig =  { 'SWIFT_ACTIVE_COMPILATION_CONDITIONS' => '$(inherited) ETE_TEST_SUITE_ENABLED' }
-    eteTestSuite.dependency    "Core"
+    eteTestSuite.pod_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
+    eteTestSuite.user_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
+    eteTestSuite.dependency    "Clickstream/Core"
   end
 
 end

--- a/Clickstream.podspec
+++ b/Clickstream.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   s.license          = { :type => 'MIT', :file => 'LICENSE' }
   
   s.author           = "Gojek"
-  s.source           = { :git => 'https://github.com/gojek/clickstream-ios.git', :tag => s.version.to_s }
+  s.source           = { :git => 'https://github.com/gojek/clickstream-ios.git', :tag => "1.1.0" }
 
   s.platform         = :ios
   s.ios.deployment_target = '11.0'
@@ -38,16 +38,19 @@ Pod::Spec.new do |s|
   s.subspec 'Tracker' do |tracker|
     tracker.source_files = 'Sources/Tracker/**/*.swift'
     tracker.xcconfig =  { 'SWIFT_ACTIVE_COMPILATION_CONDITIONS' => '$(inherited) TRACKER_ENABLED' }
+    tracker.dependency    "Core"
   end
 
   s.subspec 'EventVisualizer' do |eventVisualizer|
     eventVisualizer.source_files = 'Sources/EventVisualizer/**/*.swift'
     eventVisualizer.xcconfig =  { 'SWIFT_ACTIVE_COMPILATION_CONDITIONS' => '$(inherited) EVENT_VISUALIZER_ENABLED' }
+    eventVisualizer.dependency    "Core"
   end
 
   s.subspec 'ETETestSuite' do |eteTestSuite|
     eteTestSuite.source_files = 'Sources/ETETestSuite/**/*.swift'
     eteTestSuite.xcconfig =  { 'SWIFT_ACTIVE_COMPILATION_CONDITIONS' => '$(inherited) ETE_TEST_SUITE_ENABLED' }
+    eteTestSuite.dependency    "Core"
   end
 
 end

--- a/Clickstream.podspec
+++ b/Clickstream.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = "Clickstream"
-  s.version          = "1.0.12"
+  s.version          = "1.1.0"
   s.summary          = "Real time Analytics SDK"
   s.description      = "Clickstream is an event agnostic, real-time data ingestion analytics SDK"
 

--- a/Clickstream.podspec
+++ b/Clickstream.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = "Clickstream"
-  s.version          = "1.1.0"
+  s.version          = "1.1.1"
   s.summary          = "Real time Analytics SDK"
   s.description      = "Clickstream is an event agnostic, real-time data ingestion analytics SDK"
 
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   s.license          = { :type => 'MIT', :file => 'LICENSE' }
   
   s.author           = "Gojek"
-  s.source           = { :git => 'https://github.com/gojek/clickstream-ios.git', :tag => "1.1.0" }
+  s.source           = { :git => 'https://github.com/gojek/clickstream-ios.git', :tag => s.version }
 
   s.platform         = :ios
   s.ios.deployment_target = '11.0'

--- a/Sources/Clickstream/Core/Interface/ClickStream.swift
+++ b/Sources/Clickstream/Core/Interface/ClickStream.swift
@@ -89,7 +89,7 @@ public final class Clickstream {
     
     /// computed public property which sets
     /// and fetches the global `_stateViewer` variable
-    public static var stateViewer: EventStateViewable? {
+    public var stateViewer: EventStateViewable? {
         get {
             return Clickstream._stateViewer
         }

--- a/Sources/Clickstream/Core/Interface/ClickStream.swift
+++ b/Sources/Clickstream/Core/Interface/ClickStream.swift
@@ -89,7 +89,7 @@ public final class Clickstream {
     
     /// computed public property which sets
     /// and fetches the global `_stateViewer` variable
-    public var stateViewer: EventStateViewable? {
+    public static var stateViewer: EventStateViewable? {
         get {
             return Clickstream._stateViewer
         }

--- a/Sources/EventVisualizer/src/Helpers/EventsHelper.swift
+++ b/Sources/EventVisualizer/src/Helpers/EventsHelper.swift
@@ -27,11 +27,11 @@ final public class EventsHelper {
     }
     
     public func startCapturing() {
-        Clickstream.getInstance()?.stateViewer = self
+//        Clickstream.getInstance()?.stateViewer = self
     }
     
     public func stopCapturing() {
-        Clickstream.getInstance()?.stateViewer = nil
+//        Clickstream.getInstance()?.stateViewer = nil
     }
     public func clearData() {
         EventsHelper.shared.eventsCaptured = []

--- a/Sources/EventVisualizer/src/Helpers/EventsHelper.swift
+++ b/Sources/EventVisualizer/src/Helpers/EventsHelper.swift
@@ -27,11 +27,11 @@ final public class EventsHelper {
     }
     
     public func startCapturing() {
-//        Clickstream.getInstance()?.stateViewer = self
+        Clickstream.stateViewer = self
     }
     
     public func stopCapturing() {
-//        Clickstream.getInstance()?.stateViewer = nil
+        Clickstream.stateViewer = nil
     }
     public func clearData() {
         EventsHelper.shared.eventsCaptured = []

--- a/Sources/EventVisualizer/src/Helpers/EventsHelper.swift
+++ b/Sources/EventVisualizer/src/Helpers/EventsHelper.swift
@@ -27,11 +27,15 @@ final public class EventsHelper {
     }
     
     public func startCapturing() {
-        Clickstream.stateViewer = self
+        #if EVENT_VISUALIZER_ENABLED
+        Clickstream.getInstance()?.stateViewer = self
+        #endif
     }
     
     public func stopCapturing() {
-        Clickstream.stateViewer = nil
+        #if EVENT_VISUALIZER_ENABLED
+        Clickstream.getInstance()?.stateViewer = nil
+        #endif
     }
     public func clearData() {
         EventsHelper.shared.eventsCaptured = []


### PR DESCRIPTION
The subspec was not able to access Clickstream files, adding sources from Clickstream enables it to use Clickstream files as well