### PR TITLE
Fixed Data race condition in Network Reachability

### DIFF
--- a/Sources/ClickstreamLib/NetworkManager/Core/RetryMechanism.swift
+++ b/Sources/ClickstreamLib/NetworkManager/Core/RetryMechanism.swift
@@ -106,10 +106,10 @@ final class DefaultRetryMechanism: Retryable {
         self.persistence = persistence
         self.keepAliveService = keepAliveService
         
+        self.observeNetworkConnectivity()
         self.establishConnection()
         self.observeDeviceStatus()
         self.observeAppStateChanges()
-        self.observeNetworkConnectivity()
         self.keepConnectionAlive()
     }
     
@@ -132,7 +132,6 @@ final class DefaultRetryMechanism: Retryable {
         
     private func observeNetworkConnectivity() {
         do {
-            try reachability.startNotifier()
             reachability.whenReachable = { [weak self] (_) in
                 guard let checkedSelf = self else { return }
                 checkedSelf.establishConnection()
@@ -141,6 +140,7 @@ final class DefaultRetryMechanism: Retryable {
                 guard let checkedSelf = self else { return }
                 checkedSelf.terminateConnection()
             }
+            try reachability.startNotifier()
         } catch {
             print("Unable to start notifier")
         }


### PR DESCRIPTION
establishConnection() in RetryMechanism.swift internally checks for networkAvailability with Reachability which updates network status flags and triggers notifications in async.
observerNetworkConnectivity() adds observers for reachable and not-reachable state.
This sequence of events leads to race-condition for whenReachable and whenUnreachable observers as those are being set and get at the same time from different threads.

This MR changes sequence of events. With these changes, we add the observers first and then check for network status and try to establishConnection.