### PR TITLE
Record number of events dropped at the end for retry mechanims

### DIFF
--- a/Sources/Clickstream/Core/Data/Utilities/Reachability+Extension.swift
+++ b/Sources/Clickstream/Core/Data/Utilities/Reachability+Extension.swift
@@ -17,6 +17,7 @@ enum NetworkType: Equatable {
     case wwan2g
     case wwan3g
     case wwan4g
+    case wwan5g
     case unknownTechnology(name: String)
     
     var trackingId: String {
@@ -27,6 +28,7 @@ enum NetworkType: Equatable {
         case .wwan2g:                       return "2G"
         case .wwan3g:                       return "3G"
         case .wwan4g:                       return "4G"
+        case .wwan5g:                       return "5G"
         case .unknownTechnology(let name):  return "Unknown Technology: \"\(name)\""
         }
     }
@@ -51,7 +53,18 @@ extension Reachability {
     }
     
     internal static func getWWANNetworkType() -> NetworkType {
-        guard let currentRadioAccessTechnology = CTTelephonyNetworkInfo().currentRadioAccessTechnology else { return .unknown }
+        var _currentRadioAccessTechnology: String? = nil
+        if let accessTechnology = CTTelephonyNetworkInfo().serviceCurrentRadioAccessTechnology?.values.first{
+            _currentRadioAccessTechnology = accessTechnology
+        }
+
+        guard let currentRadioAccessTechnology = _currentRadioAccessTechnology else { return .unknown }
+        
+        if #available(iOS 14.1, *) {
+            if currentRadioAccessTechnology == CTRadioAccessTechnologyNRNSA || currentRadioAccessTechnology == CTRadioAccessTechnologyNR{
+                return .wwan5g
+            }
+        }
         switch currentRadioAccessTechnology {
         case CTRadioAccessTechnologyGPRS,
              CTRadioAccessTechnologyEdge,
@@ -70,5 +83,5 @@ extension Reachability {
         default:
             return .unknownTechnology(name: currentRadioAccessTechnology)
         }
-    }    
+    }
 }

--- a/Sources/Clickstream/EventScheduler/Core/EventWarehouser.swift
+++ b/Sources/Clickstream/EventScheduler/Core/EventWarehouser.swift
@@ -63,7 +63,8 @@ extension DefaultEventWarehouser {
                 #endif
                 #if TRACKER_ENABLED
                 let healthEvent = HealthAnalysisEvent(eventName: .ClickstreamEventCached,
-                                                      eventGUID: event.guid)
+                                                      eventGUID: event.guid,
+                                                      eventCount: 1)
                 if event.type != Constants.EventType.instant.rawValue {
                     Tracker.sharedInstance?.record(event: healthEvent)
                 }

--- a/Sources/Clickstream/NetworkManager/Core/NetworkBuilder.swift
+++ b/Sources/Clickstream/NetworkManager/Core/NetworkBuilder.swift
@@ -71,7 +71,7 @@ extension DefaultNetworkBuilder {
                     checkedSelf.trackHealthEvents(eventBatch: eventBatch,
                                                           eventBatchData: data)
                 }
-                
+                eventRequest.eventCount = eventBatch.events.count
                 checkedSelf.retryMech.trackBatch(with: eventRequest)
                 #if EVENT_VISUALIZER_ENABLED
                 /// Update status of the event batch to sent to network

--- a/Sources/Clickstream/NetworkManager/Core/NetworkBuilder.swift
+++ b/Sources/Clickstream/NetworkManager/Core/NetworkBuilder.swift
@@ -114,7 +114,8 @@ extension DefaultNetworkBuilder {
         
         let healthEvent = HealthAnalysisEvent(eventName: .ClickstreamBatchSent,
                                               events: eventGUIDsString,
-                                              eventBatchGUID: eventBatch.uuid)
+                                              eventBatchGUID: eventBatch.uuid, 
+                                              eventCount: eventBatch.events.count)
         Tracker.sharedInstance?.record(event: healthEvent)
         #endif
     }

--- a/Sources/Clickstream/NetworkManager/Core/RetryMechanism.swift
+++ b/Sources/Clickstream/NetworkManager/Core/RetryMechanism.swift
@@ -255,7 +255,8 @@ extension DefaultRetryMechanism {
                                 var healthEvent: HealthAnalysisEvent!
                                 healthEvent = HealthAnalysisEvent(eventName: .ClickstreamWriteToSocketFailed,
                                                                   eventBatchGUID: eventRequest.guid,
-                                                                  reason: FailureReason.ParsingException.rawValue)
+                                                                  reason: FailureReason.ParsingException.rawValue,
+                                                                  eventCount: eventRequest.eventCount)
                                 Tracker.sharedInstance?.record(event: healthEvent)
                                 #if ETE_TEST_SUITE_ENABLED
                                 Clickstream.ackEvent = AckEventDetails(guid: eventRequest.guid, status: "Bad Request")
@@ -269,7 +270,8 @@ extension DefaultRetryMechanism {
                     #if TRACKER_ENABLED
                     let healthEvent = HealthAnalysisEvent(eventName: .ClickstreamEventBatchErrorResponse,
                                                           eventBatchGUID: eventRequest.guid, // eventRequest.guid is the batch GUID
-                                                          reason: error.localizedDescription)
+                                                          reason: error.localizedDescription,
+                                                          eventCount: eventRequest.eventCount)
                     Tracker.sharedInstance?.record(event: healthEvent)
                     #if ETE_TEST_SUITE_ENABLED
                     Clickstream.ackEvent = AckEventDetails(guid: eventRequest.guid, status: "\(error)")
@@ -382,7 +384,8 @@ extension DefaultRetryMechanism {
                 #if TRACKER_ENABLED
                 if Tracker.debugMode {
                     let healthEvent = HealthAnalysisEvent(eventName: .ClickstreamEventBatchTimeout,
-                                                          eventBatchGUID: fetchedEventRequest.guid)
+                                                          eventBatchGUID: fetchedEventRequest.guid,
+                                                          eventCount: eventRequest.eventCount)
                     Tracker.sharedInstance?.record(event: healthEvent)
                 }
                 #endif
@@ -464,7 +467,8 @@ extension DefaultRetryMechanism {
             guard eventRequest.eventType != Constants.EventType.instant else { return }
             
             let healthEvent = HealthAnalysisEvent(eventName: .ClickstreamEventBatchSuccessAck,
-                                                  eventBatchGUID: eventRequest.guid)
+                                                  eventBatchGUID: eventRequest.guid,
+                                                  eventCount: eventRequest.eventCount)
             Tracker.sharedInstance?.record(event: healthEvent)
             
         }
@@ -480,7 +484,8 @@ extension DefaultRetryMechanism {
             guard eventRequest.eventType != Constants.EventType.instant else { return }
             
             let healthEvent = HealthAnalysisEvent(eventName: .ClickstreamEventBatchSuccessAck,
-                                                  eventBatchGUID: eventRequest.guid)
+                                                  eventBatchGUID: eventRequest.guid,
+                                                  eventCount: eventRequest.eventCount)
             Tracker.sharedInstance?.record(event: healthEvent)
             
         }

--- a/Sources/Clickstream/NetworkManager/Core/RetryMechanism.swift
+++ b/Sources/Clickstream/NetworkManager/Core/RetryMechanism.swift
@@ -383,7 +383,7 @@ extension DefaultRetryMechanism {
                 persistence.deleteOne(eventRequest.guid)
                 #if TRACKER_ENABLED
                 if Tracker.debugMode {
-                    let healthEvent = HealthAnalysisEvent(eventName: .ClickstreamEventBatchTimeout,
+                    let healthEvent = HealthAnalysisEvent(eventName: .ClickstreamEventBatchDropped,
                                                           eventBatchGUID: fetchedEventRequest.guid,
                                                           eventCount: eventRequest.eventCount)
                     Tracker.sharedInstance?.record(event: healthEvent)
@@ -460,22 +460,6 @@ extension DefaultRetryMechanism {
 }
 
 // MARK: - Track Clickstream health.
-extension DefaultRetryMechanism {
-    func trackHealthEvents(eventRequest: EventRequest) {
-        #if TRACKER_ENABLED
-        if Tracker.debugMode {
-            guard eventRequest.eventType != Constants.EventType.instant else { return }
-            
-            let healthEvent = HealthAnalysisEvent(eventName: .ClickstreamEventBatchSuccessAck,
-                                                  eventBatchGUID: eventRequest.guid,
-                                                  eventCount: eventRequest.eventCount)
-            Tracker.sharedInstance?.record(event: healthEvent)
-            
-        }
-        #endif
-    }
-}
-
 extension DefaultRetryMechanism {
     
     func trackHealthAndPerformanceEvents(eventRequest: EventRequest, startTime: Date) {

--- a/Sources/Clickstream/NetworkManager/Domain/Entities/EventRequest.swift
+++ b/Sources/Clickstream/NetworkManager/Domain/Entities/EventRequest.swift
@@ -19,6 +19,7 @@ struct EventRequest: Codable, Equatable {
     var createdTimestamp: Date?
     var eventType: Constants.EventType?
     var isInternal: Bool?
+    var eventCount: Int
     
     init(guid: String,
          data: Data? = nil) {
@@ -29,6 +30,7 @@ struct EventRequest: Codable, Equatable {
         self.createdTimestamp = Date()
         self.isInternal = false
         self.eventType = .realTime
+        self.eventCount = 0
     }
     
     static func == (lhs: Self, rhs: Self) -> Bool {
@@ -86,6 +88,10 @@ extension EventRequest: DatabasePersistable {
             t.add(column: "eventType", .text)
         }
         
-        return [("addsIsInternalToEventRequest", addsIsInternal), ("addsEventTypeToEventRequest", addsEventType)]
+        let addsEventCount: (TableAlteration) -> Void = { t in
+            t.add(column: "eventCount", .integer)
+        }
+        
+        return [("addsIsInternalToEventRequest", addsIsInternal), ("addsEventTypeToEventRequest", addsEventType), ("addsEventCountToEventRequest", addsEventCount)]
     }
 }

--- a/Sources/Clickstream/NetworkManager/Domain/Entities/EventRequest.swift
+++ b/Sources/Clickstream/NetworkManager/Domain/Entities/EventRequest.swift
@@ -64,6 +64,7 @@ extension EventRequest: DatabasePersistable {
                 t.column("data", .blob)
                 t.column("retriesMade", .text).notNull()
                 t.column("createdTimestamp", .datetime).notNull()
+                t.column("eventCount", .integer).notNull()
             }
         }
     }
@@ -89,9 +90,12 @@ extension EventRequest: DatabasePersistable {
         }
         
         let addsEventCount: (TableAlteration) -> Void = { t in
-            t.add(column: "eventCount", .integer)
+            t.add(column: "eventCount", .integer).notNull().defaults(to: 0)
         }
         
-        return [("addsIsInternalToEventRequest", addsIsInternal), ("addsEventTypeToEventRequest", addsEventType), ("addsEventCountToEventRequest", addsEventCount)]
+        return [("addsIsInternalToEventRequest", addsIsInternal), 
+                ("addsEventTypeToEventRequest", addsEventType),
+                ("addsEventCountToEventRequest", addsEventCount)
+        ]
     }
 }

--- a/Sources/Tracker/Tracker.swift
+++ b/Sources/Tracker/Tracker.swift
@@ -221,11 +221,20 @@ public final class Tracker {
                     }
                 }
             }
-            
+            var eventCount = 0
+            for e in eventNameBasedAggregation {
+                if e.eventCount > 0 {
+                    eventCount += e.eventCount
+                } else {
+                    eventCount = 0
+                    break /// break the loop and reset event count. If any one of the event has eventCount -1, final eventCount in aggregated event will be wrong and will be of no use
+                }
+            }
+
             let eventBatchGuids = eventNameBasedAggregation.compactMap { $0.eventBatchGUID }
             
             var healthEvent = Gojek_Clickstream_Internal_Health.with {
-                $0.numberOfEvents = Int64(eventGuids.count)
+                $0.numberOfEvents = eventCount > 0 ? Int64(eventCount) : Int64(eventGuids.count)
                 $0.numberOfBatches = Int64(eventBatchGuids.count)
                 $0.healthMeta = metaData
                 $0.healthMeta.eventGuid = eventGuid

--- a/Sources/Tracker/Utilities/TrackerConstants.swift
+++ b/Sources/Tracker/Utilities/TrackerConstants.swift
@@ -26,7 +26,7 @@ enum HealthEvents: String, Codable, CaseIterable {
     case ClickstreamEventBatchTriggerFailed = "Clickstream Event Batch Trigger Failed"
     case ClickstreamWriteToSocketFailed = "Clickstream Write to Socket Failed"
     case ClickstreamEventBatchErrorResponse = "Clickstream Event Batch Error response"
-    case ClickstreamEventBatchTimeout = "Clickstream Event Batch Timeout"
+    case ClickstreamEventBatchDropped = "Clickstream Event Batch Dropped"
     
     case ClickstreamConnectionSuccess = "Clickstream Connection Success"
     case ClickstreamConnectionFailure = "Clickstream Connection Failure"
@@ -80,5 +80,5 @@ public struct TrackerConstant {
         case aggregate = "aggregate"
     }
     
-    static let InstantEvents: [HealthEvents] = [.ClickstreamEventBatchTimeout, .ClickstreamConnectionSuccess, .ClickstreamConnectionFailure, .ClickstreamEventBatchErrorResponse, .ClickstreamWriteToSocketFailed, .ClickstreamEventBatchTriggerFailed]
+    static let InstantEvents: [HealthEvents] = [.ClickstreamEventBatchDropped, .ClickstreamConnectionSuccess, .ClickstreamConnectionFailure, .ClickstreamEventBatchErrorResponse, .ClickstreamWriteToSocketFailed, .ClickstreamEventBatchTriggerFailed]
 }


### PR DESCRIPTION
Current health tracker events only keeps count of event batches that are being dropped. This does not give clear picture about total number of events missed.
This change adds a new variable `eventCount` which keeps track of number of events per batch and logs it along with event batch data.