### PR TITLE
Fix default event count sent as 1 for batch_dropped event

### DIFF
--- a/Sources/Tracker/Tracker.swift
+++ b/Sources/Tracker/Tracker.swift
@@ -170,7 +170,7 @@ public final class Tracker {
             
             let healthEvent = Gojek_Clickstream_Internal_Health.with {
                 $0.eventName = event.eventName.rawValue
-                $0.numberOfEvents = 1 // Since instant events are fired one at a time
+                $0.numberOfEvents = event.eventCount == 0 ? 1 : Int64(event.eventCount)  // Since instant events are fired one at a time
                 $0.healthMeta = metaData
                 $0.healthMeta.eventGuid = eventGuid
                 let currentTimestamp = Tracker.currentNTPTimestamp ?? Date()


### PR DESCRIPTION
Fixes bug in logging event count to Clickstream Health events.
Default value 1 was sent for all the instant health events.