### PR TITLE
Fix unsupported ruby 2.6.6 for macos 14 issue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up ruby environment
         uses: ruby/setup-ruby@v1
         with:
-         ruby-version: 2.6.6 # omit if .ruby-version file exists in project, or replace with your team’s supported ruby version
+         ruby-version: 2.6.7 # omit if .ruby-version file exists in project, or replace with your team’s supported ruby version
          bundler-cache: true
 
       - name: Testing Clickstream


### PR DESCRIPTION
Fix unsupported ruby 2.6.6 for macos 14 issue
<img width="1309" alt="Screenshot 2024-06-14 at 2 11 52 PM" src="https://github.com/gojek/clickstream-ios/assets/10935538/d0a0cc3a-1a4f-4f41-b2aa-a365b660f7f2">
