### PR TITLE
Downgrading Starscream version to 4.0.5

### DIFF
--- a/Clickstream.podspec
+++ b/Clickstream.podspec
@@ -29,7 +29,7 @@ Pod::Spec.new do |s|
   s.dependency    "SwiftProtobuf", "~> 1.21.0"
   s.dependency    "ReachabilitySwift", '>= 5.0.0'
   s.dependency    "GRDB.swift", "~> 6.7.0"
-  s.dependency    "Starscream", "4.0.4"
+  s.dependency    "Starscream", "4.0.5"
   
   s.default_subspec  = 'Core'
 

--- a/Clickstream.podspec
+++ b/Clickstream.podspec
@@ -29,7 +29,7 @@ Pod::Spec.new do |s|
   s.dependency    "SwiftProtobuf", "~> 1.21.0"
   s.dependency    "ReachabilitySwift", '>= 5.0.0'
   s.dependency    "GRDB.swift", "~> 6.7.0"
-  s.dependency    "Starscream", "~> 4.0"
+  s.dependency    "Starscream", "4.0.4"
   
   s.default_subspec  = 'Core'
 

--- a/Podfile
+++ b/Podfile
@@ -12,7 +12,7 @@ def clickstream_pods
   pod 'SwiftProtobuf', '~> 1.21.0'
   pod 'ReachabilitySwift', '5.2.3'
   pod 'GRDB.swift', '~> 6.7.0'
-  pod 'Starscream', '4.0.4'
+  pod 'Starscream', '4.0.5'
 end
 
 target 'Clickstream' do

--- a/Podfile
+++ b/Podfile
@@ -12,7 +12,7 @@ def clickstream_pods
   pod 'SwiftProtobuf', '~> 1.21.0'
   pod 'ReachabilitySwift', '5.2.3'
   pod 'GRDB.swift', '~> 6.7.0'
-  pod 'Starscream', '~> 4.0.6'
+  pod 'Starscream', '4.0.4'
 end
 
 target 'Clickstream' do

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -3,13 +3,13 @@ PODS:
     - GRDB.swift/standard (= 6.7.0)
   - GRDB.swift/standard (6.7.0)
   - ReachabilitySwift (5.2.3)
-  - Starscream (4.0.8)
+  - Starscream (4.0.4)
   - SwiftProtobuf (1.21.0)
 
 DEPENDENCIES:
   - GRDB.swift (~> 6.7.0)
   - ReachabilitySwift (= 5.2.3)
-  - Starscream (~> 4.0.6)
+  - Starscream (= 4.0.4)
   - SwiftProtobuf (~> 1.21.0)
 
 SPEC REPOS:
@@ -22,9 +22,9 @@ SPEC REPOS:
 SPEC CHECKSUMS:
   GRDB.swift: df2fdb0752e88383fc314e1e5d7c3a76d52054eb
   ReachabilitySwift: 7f151ff156cea1481a8411701195ac6a984f4979
-  Starscream: 19b5533ddb925208db698f0ac508a100b884a1b9
+  Starscream: 5178aed56b316f13fa3bc55694e583d35dd414d9
   SwiftProtobuf: afced68785854575756db965e9da52bbf3dc45e7
 
-PODFILE CHECKSUM: 90f76e61798bef03c4deda5bc7d258ea40c1ddd0
+PODFILE CHECKSUM: 213a1f773842b7f54321fed274b2d0f1244f4fa5
 
 COCOAPODS: 1.15.2

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -3,13 +3,13 @@ PODS:
     - GRDB.swift/standard (= 6.7.0)
   - GRDB.swift/standard (6.7.0)
   - ReachabilitySwift (5.2.3)
-  - Starscream (4.0.4)
+  - Starscream (4.0.5)
   - SwiftProtobuf (1.21.0)
 
 DEPENDENCIES:
   - GRDB.swift (~> 6.7.0)
   - ReachabilitySwift (= 5.2.3)
-  - Starscream (= 4.0.4)
+  - Starscream (= 4.0.5)
   - SwiftProtobuf (~> 1.21.0)
 
 SPEC REPOS:
@@ -22,9 +22,9 @@ SPEC REPOS:
 SPEC CHECKSUMS:
   GRDB.swift: df2fdb0752e88383fc314e1e5d7c3a76d52054eb
   ReachabilitySwift: 7f151ff156cea1481a8411701195ac6a984f4979
-  Starscream: 5178aed56b316f13fa3bc55694e583d35dd414d9
+  Starscream: 97a24f0636451d134fbb932f2b15cefd89b1a040
   SwiftProtobuf: afced68785854575756db965e9da52bbf3dc45e7
 
-PODFILE CHECKSUM: 213a1f773842b7f54321fed274b2d0f1244f4fa5
+PODFILE CHECKSUM: bcf76ba85fc978b95b39ff51e219ec03c033cde1
 
 COCOAPODS: 1.15.2

--- a/Sources/Clickstream/NetworkManager/Infrastructure/Sockets/SocketHandler.swift
+++ b/Sources/Clickstream/NetworkManager/Infrastructure/Sockets/SocketHandler.swift
@@ -216,8 +216,8 @@ extension DefaultSocketHandler {
                 checkedSelf.connectionCallback?(.success(.cancelled))
             case .viabilityChanged(let status):
                 checkedSelf.isConnectionRequestOpen = status
-//            case .peerClosed:
-//                checkedSelf.isConnectionRequestOpen = false
+            case .peerClosed:
+                checkedSelf.isConnectionRequestOpen = false
             default:
                 break
             }
@@ -263,11 +263,11 @@ extension DefaultSocketHandler {
         guard Tracker.debugMode else { return }
         if let error = error, case HTTPUpgradeError.notAnUpgrade(let code) = error {
             
-            if code == 401 {
+            if code.0 == 401 {
                 let event = HealthAnalysisEvent(eventName: eventName,
                                                 reason: FailureReason.AuthenticationError.rawValue)
                 Tracker.sharedInstance?.record(event: event)
-            } else if code == 1008 {
+            } else if code.0 == 1008 {
                 let event = HealthAnalysisEvent(eventName: eventName,
                                                 reason: FailureReason.DuplicateID.rawValue)
                 Tracker.sharedInstance?.record(event: event)

--- a/Sources/Clickstream/NetworkManager/Infrastructure/Sockets/SocketHandler.swift
+++ b/Sources/Clickstream/NetworkManager/Infrastructure/Sockets/SocketHandler.swift
@@ -216,8 +216,8 @@ extension DefaultSocketHandler {
                 checkedSelf.connectionCallback?(.success(.cancelled))
             case .viabilityChanged(let status):
                 checkedSelf.isConnectionRequestOpen = status
-            case .peerClosed:
-                checkedSelf.isConnectionRequestOpen = false
+//            case .peerClosed:
+//                checkedSelf.isConnectionRequestOpen = false
             default:
                 break
             }
@@ -263,11 +263,11 @@ extension DefaultSocketHandler {
         guard Tracker.debugMode else { return }
         if let error = error, case HTTPUpgradeError.notAnUpgrade(let code) = error {
             
-            if code.0 == 401 {
+            if code == 401 {
                 let event = HealthAnalysisEvent(eventName: eventName,
                                                 reason: FailureReason.AuthenticationError.rawValue)
                 Tracker.sharedInstance?.record(event: event)
-            } else if code.0 == 1008 {
+            } else if code == 1008 {
                 let event = HealthAnalysisEvent(eventName: eventName,
                                                 reason: FailureReason.DuplicateID.rawValue)
                 Tracker.sharedInstance?.record(event: event)


### PR DESCRIPTION
We previously used to use 4.0.4 but it had some things which were missing which were added on 4.0.5
But now Consumer app is using 4.0.8 which is causing [this](https://console.firebase.google.com/u/0/project/consumer-app-23d4b/crashlytics/app/ios:com.go-jek.ios/issues/a0008e169b7e36da9fef4a3e30368247?time=last-ninety-days&sessionEventKey=25f4f7415c1642daae9fc0b4589384a6_1963193238939650344) crash  thus we want to downgrade our starscream