### PR TITLE
Feature: Add a generic sampling logic for any ClickStream event

### DIFF
--- a/Clickstream.xcodeproj/project.pbxproj
+++ b/Clickstream.xcodeproj/project.pbxproj
@@ -8,6 +8,12 @@
 
 /* Begin PBXBuildFile section */
 		68E7BD202456E6F10072549A /* libClickstream.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 68E7BADF244F08C00072549A /* libClickstream.a */; };
+		69CF74AF2E8CE5EC008438D0 /* EventSampler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69CF74AE2E8CE5E2008438D0 /* EventSampler.swift */; };
+		69CF74B02E8CE5EC008438D0 /* EventSampler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69CF74AE2E8CE5E2008438D0 /* EventSampler.swift */; };
+		69CF74B52E8CE616008438D0 /* EventSamplerConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69CF74B42E8CE60D008438D0 /* EventSamplerConstants.swift */; };
+		69CF74B62E8CE616008438D0 /* EventSamplerConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69CF74B42E8CE60D008438D0 /* EventSamplerConstants.swift */; };
+		69CF74B82E8CE75A008438D0 /* EventSamplerConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69CF74B72E8CE74F008438D0 /* EventSamplerConfiguration.swift */; };
+		69CF74B92E8CE75A008438D0 /* EventSamplerConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69CF74B72E8CE74F008438D0 /* EventSamplerConfiguration.swift */; };
 		6E2A2FF5A4C4820DF0F31C3C /* libPods-ClickstreamTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 0900D4ED17E642E4DA1234F8 /* libPods-ClickstreamTests.a */; };
 		98CDAC393665EEC635D0C690 /* libPods-Clickstream.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 5E561B35C0082DAE47E3BDE1 /* libPods-Clickstream.a */; };
 		9A0BBA882BC3A59300F7DC01 /* URLRequest+Equality.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A0BBA872BC3A59300F7DC01 /* URLRequest+Equality.swift */; };
@@ -220,6 +226,9 @@
 		5E561B35C0082DAE47E3BDE1 /* libPods-Clickstream.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Clickstream.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		68E7BADF244F08C00072549A /* libClickstream.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libClickstream.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		68E7BD1B2456E6F10072549A /* ClickstreamTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ClickstreamTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		69CF74AE2E8CE5E2008438D0 /* EventSampler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventSampler.swift; sourceTree = "<group>"; };
+		69CF74B42E8CE60D008438D0 /* EventSamplerConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventSamplerConstants.swift; sourceTree = "<group>"; };
+		69CF74B72E8CE74F008438D0 /* EventSamplerConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventSamplerConfiguration.swift; sourceTree = "<group>"; };
 		88F9204101C5E8D41805FD1A /* Pods-ClickstreamTests.production.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ClickstreamTests.production.xcconfig"; path = "Target Support Files/Pods-ClickstreamTests/Pods-ClickstreamTests.production.xcconfig"; sourceTree = "<group>"; };
 		9A0BBA872BC3A59300F7DC01 /* URLRequest+Equality.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URLRequest+Equality.swift"; sourceTree = "<group>"; };
 		9A0BBA8C2BC3CA5500F7DC01 /* PerformanceTracer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PerformanceTracer.swift; sourceTree = "<group>"; };
@@ -391,6 +400,16 @@
 				68E7BD1B2456E6F10072549A /* ClickstreamTests.xctest */,
 			);
 			name = Products;
+			sourceTree = "<group>";
+		};
+		69CF74AD2E8CE5CF008438D0 /* EventSampler */ = {
+			isa = PBXGroup;
+			children = (
+				69CF74B72E8CE74F008438D0 /* EventSamplerConfiguration.swift */,
+				69CF74B42E8CE60D008438D0 /* EventSamplerConstants.swift */,
+				69CF74AE2E8CE5E2008438D0 /* EventSampler.swift */,
+			);
+			path = EventSampler;
 			sourceTree = "<group>";
 		};
 		9A0BBA8B2BC3CA4000F7DC01 /* Performance */ = {
@@ -724,6 +743,7 @@
 		BDE4678C2A5BD72000BFA976 /* Clickstream */ = {
 			isa = PBXGroup;
 			children = (
+				69CF74AD2E8CE5CF008438D0 /* EventSampler */,
 				BDE4678D2A5BD72000BFA976 /* NetworkManager */,
 				BDE467A72A5BD72000BFA976 /* Core */,
 				BDE467BC2A5BD72000BFA976 /* Contracts */,
@@ -1147,9 +1167,13 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-ClickstreamTests/Pods-ClickstreamTests-resources-${CONFIGURATION}-input-files.xcfilelist",
 			);
+			inputPaths = (
+			);
 			name = "[CP] Copy Pods Resources";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-ClickstreamTests/Pods-ClickstreamTests-resources-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -1260,6 +1284,7 @@
 				BDE468312A5BD72000BFA976 /* EteExperiment.pb.swift in Sources */,
 				BDE468152A5BD72000BFA976 /* EventRequest.swift in Sources */,
 				BDE4681F2A5BD72000BFA976 /* Constants.swift in Sources */,
+				69CF74AF2E8CE5EC008438D0 /* EventSampler.swift in Sources */,
 				BDE468692A5BD72000BFA976 /* EventBatchSizeRegulator.swift in Sources */,
 				BDE468792A5BD72000BFA976 /* EventProcessor.swift in Sources */,
 				BDE468252A5BD72000BFA976 /* Logger.swift in Sources */,
@@ -1282,6 +1307,7 @@
 				BDE468192A5BD72000BFA976 /* ClickstreamDependencies.swift in Sources */,
 				BDE468772A5BD72000BFA976 /* EventClassifier.swift in Sources */,
 				BDE468712A5BD72000BFA976 /* DatabaseDAO.swift in Sources */,
+				69CF74B62E8CE616008438D0 /* EventSamplerConstants.swift in Sources */,
 				BD6BDB8229FBC1360006B04A /* EventStateViewable.swift in Sources */,
 				BD6BDB6E29FBC1360006B04A /* EventsListingTableViewCell.swift in Sources */,
 				BDE468672A5BD72000BFA976 /* AppStateNotifierService.swift in Sources */,
@@ -1297,6 +1323,7 @@
 				BDE468112A5BD72000BFA976 /* KeepAliveService.swift in Sources */,
 				BD6BDB8E29FBC1360006B04A /* TrackerConstants.swift in Sources */,
 				BDE468332A5BD72000BFA976 /* EventResponse.pb.swift in Sources */,
+				69CF74B82E8CE75A008438D0 /* EventSamplerConfiguration.swift in Sources */,
 				BDE4681B2A5BD72000BFA976 /* ClickStreamConstraints.swift in Sources */,
 				BDE468172A5BD72000BFA976 /* ClickStream.swift in Sources */,
 				BD6BDB7829FBC1360006B04A /* EventDetailsViewModel.swift in Sources */,
@@ -1308,6 +1335,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				9A0BBA892BC3A59300F7DC01 /* URLRequest+Equality.swift in Sources */,
+				69CF74B52E8CE616008438D0 /* EventSamplerConstants.swift in Sources */,
 				BD6BDB9F29FBC1360006B04A /* CSCommonPropertiesDTO.swift in Sources */,
 				BDE467752A5BD24500BFA976 /* BatchSizeRegulatorMock.swift in Sources */,
 				BDE4680E2A5BD72000BFA976 /* NetworkReachability.swift in Sources */,
@@ -1386,6 +1414,7 @@
 				BD6BDB8F29FBC1360006B04A /* TrackerConstants.swift in Sources */,
 				BDE4686A2A5BD72000BFA976 /* EventBatchSizeRegulator.swift in Sources */,
 				BD6BDB6B29FBC1360006B04A /* RadioLabelTableViewCell.swift in Sources */,
+				69CF74B92E8CE75A008438D0 /* EventSamplerConfiguration.swift in Sources */,
 				BDE4677F2A5BD24500BFA976 /* EventCreatorTests.swift in Sources */,
 				BDE468722A5BD72000BFA976 /* DatabaseDAO.swift in Sources */,
 				BDE4677E2A5BD24500BFA976 /* DatabaseDAOTests.swift in Sources */,
@@ -1402,6 +1431,7 @@
 				BDE468302A5BD72000BFA976 /* EventRequest.pb.swift in Sources */,
 				BD6BDB9529FBC1360006B04A /* HealthMeta.pb.swift in Sources */,
 				BD6BDB7329FBC1360006B04A /* EventVisualizerLandingViewController.swift in Sources */,
+				69CF74B02E8CE5EC008438D0 /* EventSampler.swift in Sources */,
 				BDE467FE2A5BD72000BFA976 /* NetworkManagerDependencies.swift in Sources */,
 				BDE467762A5BD24500BFA976 /* DatabaseMock.swift in Sources */,
 				BDDC872329E6AF580024ED8C /* FileManagerOverride.swift in Sources */,

--- a/ClickstreamTests/Core/ClickStreamDependenciesTests.swift
+++ b/ClickstreamTests/Core/ClickStreamDependenciesTests.swift
@@ -24,7 +24,7 @@ class ClickstreamDependenciesTests: XCTestCase {
         
         self.constraints = ClickstreamConstraints(maxConnectionRetries: 15, maxConnectionRetryInterval: 5, maxRetryIntervalPostPrematureDisconnection: 10, maxRetriesPostPrematureDisconnection: 20, maxPingInterval: 15, priorities: prioritiesMock, flushOnBackground: true, connectionTerminationTimerWaitTime: 2, maxRequestAckTimeout: 3, maxRetriesPerBatch: 10, maxRetryCacheSize: 100000, connectionRetryDuration: 3, flushOnAppLaunch: false, minBatteryLevelPercent: 10.0)
         
-        let eventClassifierMock = ClickstreamEventClassification.EventClassifier(identifier: "ClickstreamTestRealtime", eventNames: ["CardEvent"])
+        let eventClassifierMock = ClickstreamEventClassification.EventClassifier(identifier: "ClickstreamTestRealtime", eventNames: ["CardEvent"], csEventNames: ["GoChat", "GoPay"])
         self.eventClassifier = ClickstreamEventClassification(eventTypes: [eventClassifierMock])
     }
     

--- a/ClickstreamTests/Core/Mocks/MockConstants.swift
+++ b/ClickstreamTests/Core/Mocks/MockConstants.swift
@@ -17,9 +17,17 @@ struct MockConstants {
     }()
     
     static let eventClassification: ClickstreamEventClassification = {
-        let testRealtimeEvent = ClickstreamEventClassification.EventClassifier(identifier: "ClickstreamTestRealtime", eventNames: ["gojek.clickstream.products.events.AdCardEvent"])
-        let testStandardEvent = ClickstreamEventClassification.EventClassifier(identifier: "ClickstreamTestStandard", eventNames: ["GoChat", "GoPay"])
+        let testRealtimeEvent = ClickstreamEventClassification.EventClassifier(identifier: "ClickstreamTestRealtime", eventNames: ["gojek.clickstream.products.events.AdCardEvent"], csEventNames: ["GoChat", "GoPay"])
+        let testStandardEvent = ClickstreamEventClassification.EventClassifier(identifier: "ClickstreamTestStandard", eventNames: ["GoChat", "GoPay"], csEventNames: ["GoChat", "GoPay"])
         
         return ClickstreamEventClassification(eventTypes: [testRealtimeEvent, testStandardEvent])
+    }()
+    
+    static let eventSamplerConfigurationDefault: EventSamplerConfiguration = {
+        return EventSamplerConfiguration(defaultRate: 100)
+    }()
+    
+    static let eventSamplerConfigurationOverriders: EventSamplerConfiguration = {
+        return EventSamplerConfiguration(defaultRate: 100, overrides: ["GoChat": 50, "GoPay": 100])
     }()
 }

--- a/Sources/Clickstream/Core/Interface/ClickStream.swift
+++ b/Sources/Clickstream/Core/Interface/ClickStream.swift
@@ -173,7 +173,7 @@ public final class Clickstream {
                                                      updateConnectionStatus: Bool = false,
                                                      timerCrashFixFlag: Bool = false,
                                                      priorityEventsEnabled: Bool = false,
-                                                     appPrefix: String) throws -> Clickstream? {
+                                                     appPrefix: String, samplerConfiguration: EventSamplerConfiguration? = nil) throws -> Clickstream? {
         do {
             return try initializeClickstream(
                 with: request,
@@ -183,7 +183,7 @@ public final class Clickstream {
                 updateConnectionStatus: updateConnectionStatus,
                 timerCrashFixFlag: timerCrashFixFlag,
                 priorityEventsEnabled: priorityEventsEnabled,
-                appPrefix: appPrefix)
+                appPrefix: appPrefix, samplerConfiguration: samplerConfiguration)
         } catch {
             print("Cannot initialise Clickstream. Dependencies could not be initialised.",.critical)
             // Relay the database error.
@@ -197,7 +197,7 @@ public final class Clickstream {
                                                      delegate: ClickstreamDelegate? = nil,
                                                      updateConnectionStatus: Bool = false,
                                                      timerCrashFixFlag: Bool = false,
-                                                     appPrefix: String) throws -> Clickstream? {
+                                                     appPrefix: String, samplerConfiguration: EventSamplerConfiguration? = nil) throws -> Clickstream? {
         do {
             return try initializeClickstream(
                 with: request,
@@ -206,7 +206,7 @@ public final class Clickstream {
                 delegate: delegate,
                 updateConnectionStatus: updateConnectionStatus,
                 timerCrashFixFlag: timerCrashFixFlag,
-                appPrefix: appPrefix)
+                appPrefix: appPrefix, samplerConfiguration: samplerConfiguration)
         } catch {
             print("Cannot initialise Clickstream. Dependencies could not be initialised.",.critical)
             // Relay the database error.
@@ -222,7 +222,7 @@ public final class Clickstream {
                                       updateConnectionStatus: Bool = false,
                                       timerCrashFixFlag: Bool = false,
                                       priorityEventsEnabled: Bool = false,
-                                      appPrefix: String) throws -> Clickstream? {
+                                      appPrefix: String, samplerConfiguration: EventSamplerConfiguration? = nil) throws -> Clickstream? {
         let semaphore = DispatchSemaphore(value: 1)
         defer {
             semaphore.signal()
@@ -242,7 +242,7 @@ public final class Clickstream {
             // All the dependency injections pertaining to the clickstream blocks happen here!
             // Load default dependencies.
             do {
-                let dependencies = try DefaultClickstreamDependencies(with: request)
+                let dependencies = try DefaultClickstreamDependencies(with: request, samplerConfiguration: samplerConfiguration)
                 sharedInstance = Clickstream(networkBuilder: dependencies.networkBuilder,
                                              eventWarehouser: dependencies.eventWarehouser,
                                              eventProcessor: dependencies.eventProcessor,

--- a/Sources/Clickstream/EventProcessor/Core/EventProcessorDependencies.swift
+++ b/Sources/Clickstream/EventProcessor/Core/EventProcessorDependencies.swift
@@ -11,6 +11,7 @@ import Foundation
 final class EventProcessorDependencies {
     
     private let eventWarehouser: EventWarehouser
+    private let eventSampler: EventSampler?
     
     private lazy var serialQueue: SerialQueue = {
         return SerialQueue(label: Constants.QueueIdentifiers.processor.rawValue)
@@ -20,13 +21,14 @@ final class EventProcessorDependencies {
         return DefaultEventClassifier()
     }()
     
-    init(with eventWarehouser: EventWarehouser) {
+    init(with eventWarehouser: EventWarehouser, sampler: EventSampler? = nil) {
         self.eventWarehouser = eventWarehouser
+        self.eventSampler = sampler
     }
     
     func makeEventProcessor() -> EventProcessor {
         return DefaultEventProcessor(performOnQueue: serialQueue,
                                      classifier: classifier,
-                                     eventWarehouser: eventWarehouser)
+                                     eventWarehouser: eventWarehouser, sampler: eventSampler)
     }
 }

--- a/Sources/Clickstream/EventSampler/EventSampler.swift
+++ b/Sources/Clickstream/EventSampler/EventSampler.swift
@@ -1,0 +1,32 @@
+//
+//  EventSampler.swift
+//  Clickstream
+//
+//  Created by Rishab Habbu on 01/10/25.
+//  Copyright © 2025 Gojek. All rights reserved.
+//
+import Foundation
+
+protocol EventSampler {
+    func shouldTrack(event: ClickstreamEvent) -> Bool
+}
+
+class DefaultEventSampler: EventSampler {
+    
+    let configurations: EventSamplerConfiguration
+    
+    init(config: EventSamplerConfiguration) {
+        self.configurations = config
+    }
+    
+    func shouldTrack(event: ClickstreamEvent) -> Bool {
+        let eventName = event.eventName
+        
+        if let overrides = configurations.overrides, let sampleRate = overrides[eventName] {
+            let randomValue = Int.random(in: 1...EventSamplerConstants.defaultSampleRate)
+            return randomValue <= Int(sampleRate)
+        }
+        
+        return true
+    }
+}

--- a/Sources/Clickstream/EventSampler/EventSamplerConfiguration.swift
+++ b/Sources/Clickstream/EventSampler/EventSamplerConfiguration.swift
@@ -1,0 +1,51 @@
+//
+//  EventSamplerconfiguration.swift
+//  Clickstream
+//
+//  Created by Rishab Habbu on 01/10/25.
+//  Copyright © 2025 Gojek. All rights reserved.
+//
+
+import Foundation
+
+
+// MARK: - Root model
+public struct EventSamplerConfiguration: Codable {
+    let defaultRate: Int?
+    let overrides: [String: Int]?
+
+    enum CodingKeys: String, CodingKey {
+        case defaultRate = "default_rate"
+        case overrides
+    }
+    
+    init(defaultRate: Int = 0, overrides: [String: Int] = [:]) {
+        self.defaultRate = defaultRate
+        self.overrides = overrides
+    }
+
+    // Custom decoding with safety
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        // Decode default_rate safely (fallback = 0)
+        self.defaultRate = (try? container.decode(Int.self, forKey: .defaultRate)) ?? EventSamplerConstants.defaultSampleRate
+
+        // Decode overrides safely
+        if let overridesDict = try? container.decode([String: Int].self, forKey: .overrides) {
+            self.overrides = overridesDict
+        } else {
+            // If overrides is missing, malformed, or wrong type
+            self.overrides = [:]
+        }
+    }
+
+    // Custom encoder (optional but keeps things clean)
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(defaultRate, forKey: .defaultRate)
+        let overridesDict = overrides
+        try container.encode(overridesDict, forKey: .overrides)
+    }
+}
+

--- a/Sources/Clickstream/EventSampler/EventSamplerConstants.swift
+++ b/Sources/Clickstream/EventSampler/EventSamplerConstants.swift
@@ -1,0 +1,14 @@
+//
+//  EventSamplerConstants.swift
+//  Clickstream
+//
+//  Created by Rishab Habbu on 01/10/25.
+//  Copyright © 2025 Gojek. All rights reserved.
+//
+import Foundation
+
+struct EventSamplerConstants {
+    
+    static let defaultSampleRate: Int = 100
+}
+


### PR DESCRIPTION
## Pre requisites

- [x] I have read the [CONTRIBUTING.md](https://source.golabs.io/mobile/ios-ca-gojek/-/blob/develop/CONTRIBUTING.md) doc
- [x] I have tagged `devx-code-reviewers-ios` in #ios-pr-overflow on slack to review the MR when ready

We recommend having short-lived feature branches and merging MRs frequently. However, if you need a long-running branch, please check the exceptions listed [here](https://go-jek.atlassian.net/wiki/spaces/DEVX/pages/3170402505/RFC+Mobile+Trunk+based+development+Short+lived+feature+branches#Exceptions) to see if any of the labels apply to your case. If so, add those labels.

## Background

There have been cases where some events are added as part of a feature and the count of these events spikes when the feature is enabled in production. In this case we would add a sampling logic on every event whose count has to be reduced.

## What does the PR do?

A EventSampler on the ClickstreamSDK that accepts a config which will sample the given event name at the given rate.

Add a basic implementation detail of the feature or explain about the fix if its a bug fix here

## Is this change behind a feature flag?

- [x] Yes
- [ ] No

## RFC/JIRA ticket (if any)

Is there an RFC doc or a JIRA ticket for this feature/bugfix? Please link them here if so

## Dependent PRs (if any)

Mention dependent PRs across other repos in this section