### PR TITLE
Fix sentTime timestamp crash

### DIFF
--- a/ClickstreamTests/NetworkManagerTests/Models/CourierEventRequestTests.swift
+++ b/ClickstreamTests/NetworkManagerTests/Models/CourierEventRequestTests.swift
@@ -24,7 +24,7 @@ class CourierEventRequestTests: XCTestCase {
         
         Thread.sleep(forTimeInterval: 0.1)
         
-        try! sut.refreshBatchSentTimeStamp()
+        try! sut.refreshBatchSentTimeStamp(isCrashFixEnabled: false)
         
         let updatedProto = try! Odpf_Raccoon_EventRequest(serializedBytes: sut.data!)
         let updatedDate = updatedProto.sentTime.date
@@ -35,7 +35,42 @@ class CourierEventRequestTests: XCTestCase {
     func test_batchSentTimeRefresh_whenDataIsNil() {
         var sut = CourierEventRequest(guid: UUID().uuidString, data: nil)
         
-        XCTAssertNoThrow(try sut.refreshBatchSentTimeStamp())
+        XCTAssertNoThrow(try sut.refreshBatchSentTimeStamp(isCrashFixEnabled: false))
+    }
+    
+    func test_batchSentTimeRefresh_withValidData_whenCrashFixEnabled() {
+        let originalDate = Date()
+        let eventRequestProto = Odpf_Raccoon_EventRequest.with {
+            $0.reqGuid = UUID().uuidString
+            $0.sentTime = Google_Protobuf_Timestamp(date: originalDate)
+        }
+        
+        let protoData = try! eventRequestProto.serializedData()
+        var sut = CourierEventRequest(guid: UUID().uuidString, data: protoData)
+        
+        Thread.sleep(forTimeInterval: 0.1)
+        
+        XCTAssertNoThrow(try sut.refreshBatchSentTimeStamp(isCrashFixEnabled: true))
+        
+        let updatedProto = try! Odpf_Raccoon_EventRequest(serializedBytes: sut.data!)
+        XCTAssertGreaterThan(updatedProto.sentTime.date, originalDate)
+    }
+    
+    func test_batchSentTimeRefresh_withCorruptedData_whenCrashFixEnabled() {
+        // Arbitrary bytes that are not valid protobuf; deserialization should throw
+        // BinaryDecodingError regardless of isCrashFixEnabled.
+        let corruptData = Data([0xFF, 0xFE, 0xAB, 0xCD, 0x00, 0x11])
+        var sut = CourierEventRequest(guid: UUID().uuidString, data: corruptData)
+        
+        XCTAssertThrowsError(try sut.refreshBatchSentTimeStamp(isCrashFixEnabled: true))
+    }
+    
+    func test_batchSentTimeRefresh_withEmptyData_whenCrashFixEnabled() {
+        // Empty (non-nil) Data decodes to an empty proto successfully;
+        // the function should complete without throwing.
+        var sut = CourierEventRequest(guid: UUID().uuidString, data: Data())
+        
+        XCTAssertNoThrow(try sut.refreshBatchSentTimeStamp(isCrashFixEnabled: true))
     }
     
     func test_bumpRetriesMade() {

--- a/ClickstreamTests/NetworkManagerTests/Models/EventRequestTests.swift
+++ b/ClickstreamTests/NetworkManagerTests/Models/EventRequestTests.swift
@@ -24,7 +24,7 @@ class EventRequestTests: XCTestCase {
         
         Thread.sleep(forTimeInterval: 0.1)
         
-        try! sut.refreshBatchSentTimeStamp()
+        try! sut.refreshBatchSentTimeStamp(isCrashFixEnabled: false)
         
         let updatedProto = try! Odpf_Raccoon_EventRequest(serializedBytes: sut.data!)
         let updatedDate = updatedProto.sentTime.date
@@ -35,7 +35,42 @@ class EventRequestTests: XCTestCase {
     func test_batchSentTimeRefresh_whenDataIsNil() {
         var sut = EventRequest(guid: UUID().uuidString, data: nil)
         
-        XCTAssertNoThrow(try sut.refreshBatchSentTimeStamp())
+        XCTAssertNoThrow(try sut.refreshBatchSentTimeStamp(isCrashFixEnabled: false))
+    }
+    
+    func test_batchSentTimeRefresh_withValidData_whenCrashFixEnabled() {
+        let originalDate = Date()
+        let eventRequestProto = Odpf_Raccoon_EventRequest.with {
+            $0.reqGuid = UUID().uuidString
+            $0.sentTime = Google_Protobuf_Timestamp(date: originalDate)
+        }
+        
+        let protoData = try! eventRequestProto.serializedData()
+        var sut = EventRequest(guid: UUID().uuidString, data: protoData)
+        
+        Thread.sleep(forTimeInterval: 0.1)
+        
+        XCTAssertNoThrow(try sut.refreshBatchSentTimeStamp(isCrashFixEnabled: true))
+        
+        let updatedProto = try! Odpf_Raccoon_EventRequest(serializedBytes: sut.data!)
+        XCTAssertGreaterThan(updatedProto.sentTime.date, originalDate)
+    }
+    
+    func test_batchSentTimeRefresh_withCorruptedData_whenCrashFixEnabled() {
+        // Arbitrary bytes that are not valid protobuf; deserialization should throw
+        // BinaryDecodingError regardless of isCrashFixEnabled.
+        let corruptData = Data([0xFF, 0xFE, 0xAB, 0xCD, 0x00, 0x11])
+        var sut = EventRequest(guid: UUID().uuidString, data: corruptData)
+        
+        XCTAssertThrowsError(try sut.refreshBatchSentTimeStamp(isCrashFixEnabled: true))
+    }
+    
+    func test_batchSentTimeRefresh_withEmptyData_whenCrashFixEnabled() {
+        // Empty (non-nil) Data decodes to an empty proto successfully;
+        // the function should complete without throwing.
+        var sut = EventRequest(guid: UUID().uuidString, data: Data())
+        
+        XCTAssertNoThrow(try sut.refreshBatchSentTimeStamp(isCrashFixEnabled: true))
     }
     
     func test_bumpRetriesMade() {

--- a/Sources/Clickstream/Core/Data/Constraints/ClickStreamConstraints.swift
+++ b/Sources/Clickstream/Core/Data/Constraints/ClickStreamConstraints.swift
@@ -31,6 +31,9 @@ protocol ClickstreamConstraintsContract {
     // Connection retry duration
     var connectionRetryDuration: TimeInterval { get }
     
+    // Batch timestamp update crash-fix
+    var batchTimestampUpdateCrashFix: Bool { get }
+    
     /// This is flag which determines whether the contained events be flushed when the app is launched for the first time by the user
     var flushOnAppLaunch: Bool { get }
     
@@ -77,6 +80,9 @@ public struct ClickstreamConstraints: ClickstreamConstraintsContract {
     // Connection retry duration
     private(set) var connectionRetryDuration: TimeInterval
     
+    // Batch timestamp update crash-fix
+    private(set) var batchTimestampUpdateCrashFix: Bool
+    
     /// This is flag which determines whether the contained events be flushed when the app is launched for the first time by the user
     var flushOnAppLaunch: Bool
     
@@ -90,6 +96,7 @@ public struct ClickstreamConstraints: ClickstreamConstraintsContract {
                 flushOnBackground: Bool = true, connectionTerminationTimerWaitTime: TimeInterval = 8,
                 maxRequestAckTimeout: TimeInterval = 6, maxRetriesPerBatch: Int = 20,
                 maxRetryCacheSize: Int = 5000000, connectionRetryDuration: TimeInterval = 3,
+                batchTimestampUpdateCrashFix: Bool = false,
                 flushOnAppLaunch: Bool = false, minBatteryLevelPercent: Float = 10) {
         
         self.maxConnectionRetries = maxConnectionRetries
@@ -104,6 +111,7 @@ public struct ClickstreamConstraints: ClickstreamConstraintsContract {
         self.maxRetriesPerBatch = maxRetriesPerBatch
         self.maxRetryCacheSize = maxRetryCacheSize
         self.connectionRetryDuration = connectionRetryDuration
+        self.batchTimestampUpdateCrashFix = batchTimestampUpdateCrashFix
         self.flushOnAppLaunch = flushOnAppLaunch
         self.minBatteryLevelPercent = minBatteryLevelPercent
     }

--- a/Sources/Clickstream/Core/Data/Constraints/ClickStreamCourierConstraints.swift
+++ b/Sources/Clickstream/Core/Data/Constraints/ClickStreamCourierConstraints.swift
@@ -37,6 +37,9 @@ public struct ClickstreamCourierConstraints: ClickstreamConstraintsContract, Dec
     // Connection retry duration
     private(set) var connectionRetryDuration: TimeInterval
 
+    // Batch timestamp update crash-fix
+    private(set) var batchTimestampUpdateCrashFix: Bool
+    
     /// This is flag which determines whether the contained events be flushed when the app is launched for the first time by the user
     var flushOnAppLaunch: Bool
 
@@ -50,6 +53,7 @@ public struct ClickstreamCourierConstraints: ClickstreamConstraintsContract, Dec
                 maxRetriesPerBatch: Int = 20,
                 maxRetryCacheSize: Int = 5000000,
                 connectionRetryDuration: TimeInterval = 3,
+                batchTimestampUpdateCrashFix: Bool = false,
                 flushOnAppLaunch: Bool = false,
                 minBatteryLevelPercent: Float = 10) {
         self.priorities = priorities
@@ -59,6 +63,7 @@ public struct ClickstreamCourierConstraints: ClickstreamConstraintsContract, Dec
         self.maxRetriesPerBatch = maxRetriesPerBatch
         self.maxRetryCacheSize = maxRetryCacheSize
         self.connectionRetryDuration = connectionRetryDuration
+        self.batchTimestampUpdateCrashFix = batchTimestampUpdateCrashFix
         self.flushOnAppLaunch = flushOnAppLaunch
         self.minBatteryLevelPercent = minBatteryLevelPercent
     }
@@ -71,6 +76,7 @@ public struct ClickstreamCourierConstraints: ClickstreamConstraintsContract, Dec
         case maxRetriesPerBatch
         case maxRetryCacheSize
         case connectionRetryDuration
+        case batchTimestampUpdateCrashFix
         case flushOnAppLaunch
         case minBatteryLevelPercent
     }
@@ -85,6 +91,7 @@ public struct ClickstreamCourierConstraints: ClickstreamConstraintsContract, Dec
         maxRetriesPerBatch = try container.decodeIfPresent(Int.self, forKey: .maxRetriesPerBatch) ?? 20
         maxRetryCacheSize = try container.decodeIfPresent(Int.self, forKey: .maxRetryCacheSize) ?? 5000000
         connectionRetryDuration = try container.decodeIfPresent(TimeInterval.self, forKey: .connectionRetryDuration) ?? 3
+        batchTimestampUpdateCrashFix = try container.decodeIfPresent(Bool.self, forKey: .batchTimestampUpdateCrashFix) ?? false
         flushOnAppLaunch = try container.decodeIfPresent(Bool.self, forKey: .flushOnAppLaunch) ?? false
         minBatteryLevelPercent = try container.decodeIfPresent(Float.self, forKey: .minBatteryLevelPercent) ?? 10
     }

--- a/Sources/Clickstream/NetworkManager/Courier/CourierRetryMechanism.swift
+++ b/Sources/Clickstream/NetworkManager/Courier/CourierRetryMechanism.swift
@@ -484,9 +484,11 @@ extension CourierRetryMechanism {
                     
                     do {
                         // Refresh the timeStamp before sending the batch!
-                        try _batch.refreshBatchSentTimeStamp()
+                        let isCrashFixEnabled = Clickstream.courierConfigurations.batchTimestampUpdateCrashFix
+                        try _batch.refreshBatchSentTimeStamp(isCrashFixEnabled: isCrashFixEnabled)
                     } catch {
-                        print("Failed to update batch time on retry. Description: \(error)",.critical)
+                        print("Failed to update batch time on retry. Description: \(error)", .critical)
+                        checkedSelf.trackHealthEventBatchRetryFailed(eventRequest: _batch)
                     }
                     checkedSelf.retryFailedBatch(with: _batch)
                 }
@@ -551,6 +553,21 @@ extension CourierRetryMechanism {
             let healthEvent = HealthAnalysisEvent(eventName: .Courier_ClickstreamEventBatchSuccessAck,
                                                   eventBatchGUID: eventRequest.guid,
                                                   eventCount: eventRequest.eventCount)
+            Tracker.sharedInstance?.record(event: healthEvent)
+            
+        }
+        #endif
+    }
+    
+    func trackHealthEventBatchRetryFailed(eventRequest: CourierEventRequest) {
+        #if TRACKER_ENABLED
+        if Tracker.debugMode {
+            guard eventRequest.eventType != Constants.EventType.instant else { return }
+            
+            let healthEvent = HealthAnalysisEvent(eventName: .ClickstreamEventBatchRetryFailed,
+                                                  eventBatchGUID: eventRequest.guid,
+                                                  eventCount: eventRequest.eventCount)
+                                                  
             Tracker.sharedInstance?.record(event: healthEvent)
             
         }

--- a/Sources/Clickstream/NetworkManager/Domain/Entities/Interfaces/EventRequestPersistable.swift
+++ b/Sources/Clickstream/NetworkManager/Domain/Entities/Interfaces/EventRequestPersistable.swift
@@ -41,12 +41,18 @@ extension EventRequestPersistable {
     }
 
     mutating func refreshBatchSentTimeStamp() throws {
-        guard let data else {
+        guard let data, !data.isEmpty else {
             return
         }
 
         var requestProto = try Odpf_Raccoon_EventRequest(serializedBytes: data)
         requestProto.sentTime = Google_Protobuf_Timestamp(date: Date())
-        self.data = try requestProto.serializedData()
+
+        do {
+            self.data = try requestProto.serializedData()
+        } catch is BinaryEncodingError {
+            // Fallback to partial encoding for malformed payloads that fail full validation.
+            self.data = try requestProto.serializedData(partial: true)
+        }
     }
 }

--- a/Sources/Clickstream/NetworkManager/Domain/Entities/Interfaces/EventRequestPersistable.swift
+++ b/Sources/Clickstream/NetworkManager/Domain/Entities/Interfaces/EventRequestPersistable.swift
@@ -40,19 +40,25 @@ extension EventRequestPersistable {
         self.timeStamp = Date()
     }
 
-    mutating func refreshBatchSentTimeStamp() throws {
-        guard let data, !data.isEmpty else {
+    mutating func refreshBatchSentTimeStamp(isCrashFixEnabled: Bool) throws {
+        guard let data else {
             return
         }
 
         var requestProto = try Odpf_Raccoon_EventRequest(serializedBytes: data)
         requestProto.sentTime = Google_Protobuf_Timestamp(date: Date())
 
-        do {
+        if isCrashFixEnabled && !data.isEmpty {
+            let updatedData: Data
+            do {
+                updatedData = try requestProto.serializedData()
+            } catch is BinaryEncodingError {
+                // Fallback to partial encoding for malformed payloads that fail full validation.
+                updatedData = try requestProto.serializedData(partial: true)
+            }
+            self.data = updatedData
+        } else {
             self.data = try requestProto.serializedData()
-        } catch is BinaryEncodingError {
-            // Fallback to partial encoding for malformed payloads that fail full validation.
-            self.data = try requestProto.serializedData(partial: true)
         }
     }
 }

--- a/Sources/Clickstream/NetworkManager/Websocket/WebsocketRetryMechanism.swift
+++ b/Sources/Clickstream/NetworkManager/Websocket/WebsocketRetryMechanism.swift
@@ -421,7 +421,8 @@ extension WebsocketRetryMechanism {
                         // Refresh the timeStamp before sending the batch!
                         try _batch.refreshBatchSentTimeStamp()
                     } catch {
-                        print("Failed to update batch time on retry. Description: \(error)",.critical)
+                        print("Failed to update batch time on retry. Description: \(error)", .critical)
+                        checkedSelf.trackHealthEventBatchRetryFailed(eventRequest: _batch)
                     }
                     checkedSelf.trackBatch(with: _batch)
                 }
@@ -441,6 +442,21 @@ extension WebsocketRetryMechanism {
             let healthEvent = HealthAnalysisEvent(eventName: .ClickstreamEventBatchSuccessAck,
                                                   eventBatchGUID: eventRequest.guid,
                                                   eventCount: eventRequest.eventCount)
+            Tracker.sharedInstance?.record(event: healthEvent)
+            
+        }
+        #endif
+    }
+
+    func trackHealthEventBatchRetryFailed(eventRequest: EventRequest) {
+        #if TRACKER_ENABLED
+        if Tracker.debugMode {
+            guard eventRequest.eventType != Constants.EventType.instant else { return }
+            
+            let healthEvent = HealthAnalysisEvent(eventName: .ClickstreamEventBatchRetryFailed,
+                                                  eventBatchGUID: eventRequest.guid,
+                                                  eventCount: eventRequest.eventCount)
+                                                  
             Tracker.sharedInstance?.record(event: healthEvent)
             
         }

--- a/Sources/Clickstream/NetworkManager/Websocket/WebsocketRetryMechanism.swift
+++ b/Sources/Clickstream/NetworkManager/Websocket/WebsocketRetryMechanism.swift
@@ -419,7 +419,8 @@ extension WebsocketRetryMechanism {
                     
                     do {
                         // Refresh the timeStamp before sending the batch!
-                        try _batch.refreshBatchSentTimeStamp()
+                        let isCrashFixEnabled = Clickstream.configurations.batchTimestampUpdateCrashFix
+                        try _batch.refreshBatchSentTimeStamp(isCrashFixEnabled: isCrashFixEnabled)
                     } catch {
                         print("Failed to update batch time on retry. Description: \(error)", .critical)
                         checkedSelf.trackHealthEventBatchRetryFailed(eventRequest: _batch)

--- a/Sources/Tracker/Utilities/TrackerConstants.swift
+++ b/Sources/Tracker/Utilities/TrackerConstants.swift
@@ -21,6 +21,7 @@ enum HealthEvents: String, Codable, CaseIterable {
     case ClickstreamEventBatchCreated = "Clickstream Event Batch Created" // Clickstream
     case ClickstreamBatchSent = "Clickstream Batch Sent" // Clickstream
     case ClickstreamEventBatchSuccessAck = "Clickstream Event Batch Success Ack" // Clickstream
+    case ClickstreamEventBatchRetryFailed = "Clickstream Event Batch Retry Failed" // Clickstream
     case ClickstreamFlushOnBackground = "Clickstream Flush On Background" // Clickstream
     case ClickstreamFlushOnForeground = "Clickstream Flush On Foreground" // Clickstream
     


### PR DESCRIPTION
## Background
Crash occurs when updating sentTime via proto's serialized data 

## Changes
Add `isPartial` serialization fallback and guard check 