### PR TITLE
fix: prevent leakage of EV build setting flags to main app

### DIFF
--- a/Clickstream.podspec
+++ b/Clickstream.podspec
@@ -41,15 +41,15 @@ Pod::Spec.new do |s|
   end
 
   s.subspec 'Tracker' do |tracker|
-    tracker.xcconfig =  { 'SWIFT_ACTIVE_COMPILATION_CONDITIONS' => '$(inherited) TRACKER_ENABLED' }
+    tracker.pod_target_xcconfig =  { 'SWIFT_ACTIVE_COMPILATION_CONDITIONS' => '$(inherited) TRACKER_ENABLED' }
   end
 
   s.subspec 'EventVisualizer' do |eventVisualizer|
-    eventVisualizer.xcconfig =  { 'SWIFT_ACTIVE_COMPILATION_CONDITIONS' => '$(inherited) EVENT_VISUALIZER_ENABLED' }
+    eventVisualizer.pod_target_xcconfig =  { 'SWIFT_ACTIVE_COMPILATION_CONDITIONS' => '$(inherited) EVENT_VISUALIZER_ENABLED' }
   end
 
   s.subspec 'ETETestSuite' do |eteTestSuite|
-    eteTestSuite.xcconfig =  { 'SWIFT_ACTIVE_COMPILATION_CONDITIONS' => '$(inherited) ETE_TEST_SUITE_ENABLED' }
+    eteTestSuite.pod_target_xcconfig =  { 'SWIFT_ACTIVE_COMPILATION_CONDITIONS' => '$(inherited) ETE_TEST_SUITE_ENABLED' }
   end
 
 end


### PR DESCRIPTION
fix: prevent leakage of build setting flags to main app by using `pod_target_xcconfig` instead of `xcconfig`

## Before this change

<img width="873" height="95" alt="Screenshot 2026-05-08 at 12 54 20" src="https://github.com/user-attachments/assets/e32f2412-908e-4420-b343-d26175f505f9" />

## After this change

<img width="484" height="83" alt="Screenshot 2026-05-08 at 12 54 43" src="https://github.com/user-attachments/assets/2777e178-9ef0-42e6-b0b3-a8b5afb271bf" />
