### PR TITLE
Fix shared GRDB migrator abort causing missing courierEvent.expiryTime column

### DIFF
--- a/Sources/Clickstream/Core/Domain/Entities/Courier/CourierEvent.swift
+++ b/Sources/Clickstream/Core/Domain/Entities/Courier/CourierEvent.swift
@@ -50,7 +50,7 @@ extension CourierEvent {
     static var tableMigrations: [(version: VersionIdentifier, alteration: (TableAlteration) -> Void)]? {
         // Setting the default value of ttl to 6 months from now the existing entries on DB will have 6 months to live
         let time_to_live: (TableAlteration) -> Void = { t in
-            t.add(column: "expiryTime", .double).notNull().defaults(to: Calendar.current.date(byAdding: .month, value: 6, to: Date()) ?? Date())
+            t.add(column: "expiryTime", .datetime).notNull().defaults(to: Calendar.current.date(byAdding: .month, value: 6, to: Date()) ?? Date())
         }
         
         return [("adds_ttl_to_courier_event_table", time_to_live)

--- a/Sources/Clickstream/EventScheduler/Data/Persistence/Database/DatabaseHandler.swift
+++ b/Sources/Clickstream/EventScheduler/Data/Persistence/Database/DatabaseHandler.swift
@@ -22,7 +22,7 @@ protocol Database {
     ///   - t: A TableDefinable type is passed to define the table characteristics.
     ///   - completion: a completion callback for the table creation
     func createTable(_ t: TableDefinable.Type, _ completion: @escaping ()-> Void) throws
-        
+    
     /// Use this method to insert a supported type to db.
     /// - Parameter object: a `DatabasePersistable` object to be inserted.
     func insert(_ object: DatabasePersistable) throws
@@ -55,7 +55,7 @@ protocol Database {
     ///   - value: A value for the where clause.
     ///   - n: The count of the objects to be deleted.
     func deleteWhere<T: DatabasePersistable>(_ column: Column, value: String, n: Int) throws -> [T]?
-
+    
     /// Use this method to delete first `n` objects from a table with a `where` clause,
     /// restricted to rows whose TTL column is still in the future (i.e. not expired).
     /// Only applicable to types conforming to `TTLPersistable`.
@@ -64,14 +64,14 @@ protocol Database {
     ///   - value: A value for the where clause.
     ///   - n: The count of the objects to be deleted. If `n == 0` delete all matches.
     func deleteWhereNotExpired<T: DatabasePersistable & TTLPersistable>(_ column: Column, value: String, n: Int) throws -> [T]?
-
+    
     /// Use this method to delete objects from a table where the given column's value is
     /// strictly less than the supplied value.
     /// - Parameters:
     ///   - column: GRDB column to evaluate.
     ///   - lessThan: The upper bound (exclusive) for the where clause.
     func deleteWhere<T: DatabasePersistable>(_ column: Column, lessThan value: DatabaseValueConvertible) throws -> [T]?
-
+    
     /// Suggests whether a table with the name exists or not.
     /// - Parameter name: name of table.
     func doesTableExist(with name: String) throws -> Bool?
@@ -143,14 +143,14 @@ final class DefaultDatabase: Database {
     /// is available.
     private func reportDatabaseCorruption() {
         #if TRACKER_ENABLED
-        if Tracker.debugMode {
-            if let healthEvent = HealthAnalysisEvent(eventName: .ClickstreamDBCorrupted,
-                                                     reason: FailureReason.db_corrupted.rawValue) {
-                Tracker.sharedInstance?.record(event: healthEvent)
-            } else {
-                Tracker.pendingDatabaseCorruptionRecovery = true
+            if Tracker.debugMode {
+                if let healthEvent = HealthAnalysisEvent(eventName: .ClickstreamDBCorrupted,
+                                                        reason: FailureReason.db_corrupted.rawValue) {
+                    Tracker.sharedInstance?.record(event: healthEvent)
+                } else {
+                    Tracker.pendingDatabaseCorruptionRecovery = true
+                }
             }
-        }
         #endif
     }
     
@@ -226,7 +226,7 @@ final class DefaultDatabase: Database {
             try migrator.migrate(dbWriter)
         }
     }
-
+    
     /// Returns `true` when the error is SQLite's "duplicate column name" failure, raised when a
     /// migration tries to add a column that already exists on the table.
     private static func isDuplicateColumn(_ error: DatabaseError) -> Bool {
@@ -256,20 +256,16 @@ extension DefaultDatabase {
     }
     
     func fetchAll<T>() throws -> [T]? where T: DatabasePersistable {
-        try autoreleasepool {
-            try dbWriter?.read { db in
-                let objects = try T.fetchAll(db)
-                return objects
-            }
+        try dbWriter?.read { db in
+            let objects = try T.fetchAll(db)
+            return objects
         }
     }
     
     func fetchFirst<T>(_ n : Int) throws -> [T]? where T: DatabasePersistable {
-        try autoreleasepool {
-            try dbWriter?.read { db in
-                let objects = try T.limit(n).fetchAll(db)
-                return objects
-            }
+        try dbWriter?.read { db in
+            let objects = try T.limit(n).fetchAll(db)
+            return objects
         }
     }
     
@@ -281,35 +277,31 @@ extension DefaultDatabase {
     }
     
     func deleteAll<T>() throws -> [T]? where T: DatabasePersistable {
-        try autoreleasepool {
-            try dbWriter?.write { db in
-                let objects = try T.fetchAll(db)
-                _ = try T.deleteAll(db)
-                return objects
-            }
+        try dbWriter?.write { db in
+            let objects = try T.fetchAll(db)
+            _ = try T.deleteAll(db)
+            return objects
         }
     }
     
     func deleteOne<T>(_ primaryKeyValue: String) throws -> T? where T: DatabasePersistable {
-        try autoreleasepool {
-            try dbWriter?.write { db in
-                let object = try T.filter(Column(T.primaryKey) == primaryKeyValue).fetchAll(db)
-                try T.filter(Column(T.primaryKey) == primaryKeyValue).deleteAll(db)
-                return object.first
-            }
+        try dbWriter?.write { db in
+            let object = try T.filter(Column(T.primaryKey) == primaryKeyValue).fetchAll(db)
+            try T.filter(Column(T.primaryKey) == primaryKeyValue).deleteAll(db)
+            return object.first
         }
+        
     }
     
     func deleteWhere<T>(_ column: Column, value: String, n: Int) throws -> [T]? where T : DatabasePersistable {
-        try autoreleasepool {
-            try dbWriter?.write { db in
-                let objects = n > 0 ? try T.limit(n).filter(column == value).fetchAll(db) : try T.filter(column == value).fetchAll(db)
-                _ = n > 0 ? try T.limit(n).filter(column == value).deleteAll(db) : try T.filter(column == value).deleteAll(db)
-                return objects
-            }
+        try dbWriter?.write { db in
+            let objects = n > 0 ? try T.limit(n).filter(column == value).fetchAll(db) : try T.filter(column == value).fetchAll(db)
+            _ = n > 0 ? try T.limit(n).filter(column == value).deleteAll(db) : try T.filter(column == value).deleteAll(db)
+            return objects
         }
+        
     }
-
+    
     func deleteWhereNotExpired<T>(_ column: Column, value: String, n: Int) throws -> [T]? where T : DatabasePersistable & TTLPersistable {
         try dbWriter?.write { db in
             let baseRequest = T.filter(column == value && T.ttlColumn >= Date())
@@ -319,7 +311,7 @@ extension DefaultDatabase {
             return objects
         }
     }
-
+    
     func deleteWhere<T>(_ column: Column, lessThan value: DatabaseValueConvertible) throws -> [T]? where T : DatabasePersistable {
         try dbWriter?.write { db in
             let objects = try T.filter(column < value).fetchAll(db)
@@ -328,4 +320,3 @@ extension DefaultDatabase {
         }
     }
 }
-

--- a/Sources/Clickstream/EventScheduler/Data/Persistence/Database/DatabaseHandler.swift
+++ b/Sources/Clickstream/EventScheduler/Data/Persistence/Database/DatabaseHandler.swift
@@ -207,8 +207,17 @@ final class DefaultDatabase: Database {
         t.tableMigrations?.forEach { migration in
             if !registeredMigrations.contains(migration.version) {
                 registeredMigrations.insert(migration.version)
+                let tableName = t.description
                 migrator.registerMigration(migration.version) { db in
-                    try db.alter(table: (t.description), body: migration.alteration)
+                    do {
+                        try db.alter(table: tableName, body: migration.alteration)
+                    } catch let error as DatabaseError where Self.isDuplicateColumn(error) {
+                        // The column already exists, either because it is part of the table's
+                        // base `tableDefinition` for fresh installs, or because a prior run added
+                        // it. Treat the migration as a no-op so the shared migrator records it as
+                        // applied and does not abort, which would otherwise skip every migration
+                        // registered after it (e.g. `adds_ttl_to_courier_event_table`).
+                    }
                 }
             }
         }
@@ -216,6 +225,12 @@ final class DefaultDatabase: Database {
         if let dbWriter = dbWriter {
             try migrator.migrate(dbWriter)
         }
+    }
+
+    /// Returns `true` when the error is SQLite's "duplicate column name" failure, raised when a
+    /// migration tries to add a column that already exists on the table.
+    private static func isDuplicateColumn(_ error: DatabaseError) -> Bool {
+        (error.message?.lowercased().contains("duplicate column")) == true
     }
 }
 
@@ -313,3 +328,4 @@ extension DefaultDatabase {
         }
     }
 }
+

--- a/Sources/Clickstream/EventScheduler/Data/Persistence/Database/DatabaseHandler.swift
+++ b/Sources/Clickstream/EventScheduler/Data/Persistence/Database/DatabaseHandler.swift
@@ -22,40 +22,40 @@ protocol Database {
     ///   - t: A TableDefinable type is passed to define the table characteristics.
     ///   - completion: a completion callback for the table creation
     func createTable(_ t: TableDefinable.Type, _ completion: @escaping ()-> Void) throws
-    
+        
     /// Use this method to insert a supported type to db.
     /// - Parameter object: a `DatabasePersistable` object to be inserted.
     func insert(_ object: DatabasePersistable) throws
-    
+        
     /// Use this method to update a supported type in db.
     /// - Parameter object: a `DatabasePersistable` object to be updated.
     func update(_ object: DatabasePersistable) throws
-    
+        
     /// Use this method to fetchAll objects for a type.
     func fetchAll<T: DatabasePersistable>() throws -> [T]?
-    
+        
     /// Use this method to fetch first `n` objects from the db.
     /// - Parameter n: The count of the objects to be fetched.
     func fetchFirst<T: DatabasePersistable>(_ n : Int) throws -> [T]?
-    
+        
     /// Use this method to fetch one object for a given primaryKeyValue.
     /// - Parameter primaryKeyValue: primary key value
     func fetchOne<T: DatabasePersistable>(_ primaryKeyValue: String) throws -> T?
-    
+        
     /// Use this method to delete all the objects from a table in the db.
     func deleteAll<T: DatabasePersistable>() throws -> [T]?
-    
+        
     /// Use this method to delete one object for a given primaryKeyValue.
     /// - Parameter primaryKeyValue: primary key value
     func deleteOne<T: DatabasePersistable>(_ primaryKeyValue: String) throws -> T?
-    
+        
     /// Use this method to delete first `n` objects from a table with a `where` clause.
     /// - Parameters:
     ///   - column: GRDB column
     ///   - value: A value for the where clause.
     ///   - n: The count of the objects to be deleted.
     func deleteWhere<T: DatabasePersistable>(_ column: Column, value: String, n: Int) throws -> [T]?
-    
+        
     /// Use this method to delete first `n` objects from a table with a `where` clause,
     /// restricted to rows whose TTL column is still in the future (i.e. not expired).
     /// Only applicable to types conforming to `TTLPersistable`.
@@ -64,14 +64,14 @@ protocol Database {
     ///   - value: A value for the where clause.
     ///   - n: The count of the objects to be deleted. If `n == 0` delete all matches.
     func deleteWhereNotExpired<T: DatabasePersistable & TTLPersistable>(_ column: Column, value: String, n: Int) throws -> [T]?
-    
+        
     /// Use this method to delete objects from a table where the given column's value is
     /// strictly less than the supplied value.
     /// - Parameters:
     ///   - column: GRDB column to evaluate.
     ///   - lessThan: The upper bound (exclusive) for the where clause.
     func deleteWhere<T: DatabasePersistable>(_ column: Column, lessThan value: DatabaseValueConvertible) throws -> [T]?
-    
+        
     /// Suggests whether a table with the name exists or not.
     /// - Parameter name: name of table.
     func doesTableExist(with name: String) throws -> Bool?

--- a/Sources/Clickstream/EventScheduler/Data/Persistence/Database/DatabaseHandler.swift
+++ b/Sources/Clickstream/EventScheduler/Data/Persistence/Database/DatabaseHandler.swift
@@ -22,40 +22,40 @@ protocol Database {
     ///   - t: A TableDefinable type is passed to define the table characteristics.
     ///   - completion: a completion callback for the table creation
     func createTable(_ t: TableDefinable.Type, _ completion: @escaping ()-> Void) throws
-        
+
     /// Use this method to insert a supported type to db.
     /// - Parameter object: a `DatabasePersistable` object to be inserted.
     func insert(_ object: DatabasePersistable) throws
-        
+
     /// Use this method to update a supported type in db.
     /// - Parameter object: a `DatabasePersistable` object to be updated.
     func update(_ object: DatabasePersistable) throws
-        
+
     /// Use this method to fetchAll objects for a type.
     func fetchAll<T: DatabasePersistable>() throws -> [T]?
-        
+
     /// Use this method to fetch first `n` objects from the db.
     /// - Parameter n: The count of the objects to be fetched.
     func fetchFirst<T: DatabasePersistable>(_ n : Int) throws -> [T]?
-        
+
     /// Use this method to fetch one object for a given primaryKeyValue.
     /// - Parameter primaryKeyValue: primary key value
     func fetchOne<T: DatabasePersistable>(_ primaryKeyValue: String) throws -> T?
-        
+
     /// Use this method to delete all the objects from a table in the db.
     func deleteAll<T: DatabasePersistable>() throws -> [T]?
-        
+
     /// Use this method to delete one object for a given primaryKeyValue.
     /// - Parameter primaryKeyValue: primary key value
     func deleteOne<T: DatabasePersistable>(_ primaryKeyValue: String) throws -> T?
-        
+
     /// Use this method to delete first `n` objects from a table with a `where` clause.
     /// - Parameters:
     ///   - column: GRDB column
     ///   - value: A value for the where clause.
     ///   - n: The count of the objects to be deleted.
     func deleteWhere<T: DatabasePersistable>(_ column: Column, value: String, n: Int) throws -> [T]?
-        
+
     /// Use this method to delete first `n` objects from a table with a `where` clause,
     /// restricted to rows whose TTL column is still in the future (i.e. not expired).
     /// Only applicable to types conforming to `TTLPersistable`.
@@ -64,14 +64,14 @@ protocol Database {
     ///   - value: A value for the where clause.
     ///   - n: The count of the objects to be deleted. If `n == 0` delete all matches.
     func deleteWhereNotExpired<T: DatabasePersistable & TTLPersistable>(_ column: Column, value: String, n: Int) throws -> [T]?
-        
+
     /// Use this method to delete objects from a table where the given column's value is
     /// strictly less than the supplied value.
     /// - Parameters:
     ///   - column: GRDB column to evaluate.
     ///   - lessThan: The upper bound (exclusive) for the where clause.
     func deleteWhere<T: DatabasePersistable>(_ column: Column, lessThan value: DatabaseValueConvertible) throws -> [T]?
-        
+
     /// Suggests whether a table with the name exists or not.
     /// - Parameter name: name of table.
     func doesTableExist(with name: String) throws -> Bool?

--- a/Sources/Tracker/Health/HealthTracker.swift
+++ b/Sources/Tracker/Health/HealthTracker.swift
@@ -103,21 +103,17 @@ final class HealthTracker {
     
     @discardableResult
     func flushFunnelEvents() -> [HealthAnalysisEvent]? {
-        queue.sync {
-            let trackedVia: TrackedVia = Tracker.healthTrackingConfigs.trackedVia == .both ? .both : .internal
-            if let doesTableExist = _persistence.doesTableExist(with: HealthAnalysisEvent.description), doesTableExist {
-                return _persistence.deleteWhere(HealthAnalysisEvent.Columns.trackedVia,
-                                                value: trackedVia.rawValue)
-            }
-            return nil
+        let trackedVia: TrackedVia = Tracker.healthTrackingConfigs.trackedVia == .both ? .both : .internal
+        if let doesTableExist = _persistence.doesTableExist(with: HealthAnalysisEvent.description), doesTableExist {
+            return _persistence.deleteWhere(HealthAnalysisEvent.Columns.trackedVia,
+                                            value: trackedVia.rawValue)
         }
+        return nil
     }
     
     func deleteHealthDataOnAppUpgrade() {
-        queue.sync {
-            if let doesTableExist = _persistence.doesTableExist(with: HealthAnalysisEvent.description), doesTableExist {
-                _persistence.deleteAll()
-            }
+        if let doesTableExist = _persistence.doesTableExist(with: HealthAnalysisEvent.description), doesTableExist {
+            _persistence.deleteAll()
         }
     }
 }


### PR DESCRIPTION
**Summary:**
Fixes a database migration failure where courierEvent inserts fail with table courierEvent has no column named expiryTime, and logs show duplicate column name: eventCount for eventRequest and healthAnalysisEvent.

The root cause is a shared DatabaseMigrator that aborts the entire migration chain when any ALTER TABLE ADD COLUMN hits a column that already exists. That blocks later migrations — including adds_ttl_to_courier_event_table — from ever running on existing databases.

**Problem:** 
Clickstream uses one shared DatabaseMigrator per database (utility / wal). Every table registers its migrations into that single migrator, and migrator.migrate() runs them all in registration order.

**Solution:**
Make migrations idempotent (DatabaseHandler.swift)
Wrap each migration ALTER in a do/catch.
Treat SQLite duplicate column name as a no-op.
Let GRDB record the migration as applied so the shared chain continues and later migrations (e.g. expiryTime) run.
Align CourierEvent migration type (CourierEvent.swift)
Change expiryTime migration from .double to .datetime to match tableDefinition and the Swift model (Date).