### PR TITLE
[CNTNRSDK-824] track binary implementation

### DIFF
--- a/Clickstream.xcodeproj/project.pbxproj
+++ b/Clickstream.xcodeproj/project.pbxproj
@@ -26,6 +26,9 @@
 		9A0BBA892BC3A59300F7DC01 /* URLRequest+Equality.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A0BBA872BC3A59300F7DC01 /* URLRequest+Equality.swift */; };
 		9A0BBA8D2BC3CA5500F7DC01 /* PerformanceTracer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A0BBA8C2BC3CA5500F7DC01 /* PerformanceTracer.swift */; };
 		9A0BBA8E2BC3CA5500F7DC01 /* PerformanceTracer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A0BBA8C2BC3CA5500F7DC01 /* PerformanceTracer.swift */; };
+		9F60491D2FC9781700190D5C /* CSBinaryEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F60491C2FC9781700190D5C /* CSBinaryEvent.swift */; };
+		9F60491E2FC9781700190D5C /* CSBinaryEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F60491C2FC9781700190D5C /* CSBinaryEvent.swift */; };
+		9F6049202FC979B700190D5C /* CSBinaryEventTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F60491F2FC979B700190D5C /* CSBinaryEventTests.swift */; };
 		BD6BDB6829FBC1360006B04A /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = BD6BDB3E29FBC1360006B04A /* Assets.xcassets */; };
 		BD6BDB6929FBC1360006B04A /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = BD6BDB3E29FBC1360006B04A /* Assets.xcassets */; };
 		BD6BDB6A29FBC1360006B04A /* RadioLabelTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD6BDB4129FBC1360006B04A /* RadioLabelTableViewCell.swift */; };
@@ -325,6 +328,8 @@
 		88F9204101C5E8D41805FD1A /* Pods-ClickstreamTests.production.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ClickstreamTests.production.xcconfig"; path = "Target Support Files/Pods-ClickstreamTests/Pods-ClickstreamTests.production.xcconfig"; sourceTree = "<group>"; };
 		9A0BBA872BC3A59300F7DC01 /* URLRequest+Equality.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URLRequest+Equality.swift"; sourceTree = "<group>"; };
 		9A0BBA8C2BC3CA5500F7DC01 /* PerformanceTracer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PerformanceTracer.swift; sourceTree = "<group>"; };
+		9F60491C2FC9781700190D5C /* CSBinaryEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CSBinaryEvent.swift; sourceTree = "<group>"; };
+		9F60491F2FC979B700190D5C /* CSBinaryEventTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CSBinaryEventTests.swift; sourceTree = "<group>"; };
 		9D31FA91B32979CBBA2C3849 /* Pods-ClickstreamTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ClickstreamTests.debug.xcconfig"; path = "Target Support Files/Pods-ClickstreamTests/Pods-ClickstreamTests.debug.xcconfig"; sourceTree = "<group>"; };
 		A870FFC059A664D0DF0292E5 /* Pods-ClickstreamTests.alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ClickstreamTests.alpha.xcconfig"; path = "Target Support Files/Pods-ClickstreamTests/Pods-ClickstreamTests.alpha.xcconfig"; sourceTree = "<group>"; };
 		A8F29FD3E426DD04C26B8560 /* Pods-ClickstreamTests.integration.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ClickstreamTests.integration.xcconfig"; path = "Target Support Files/Pods-ClickstreamTests/Pods-ClickstreamTests.integration.xcconfig"; sourceTree = "<group>"; };
@@ -769,6 +774,7 @@
 				D8A7F7D52EC6B94500DFC9AE /* Courier */,
 				BDE467492A5BD24500BFA976 /* EventBatchTests.swift */,
 				BDE4674A2A5BD24500BFA976 /* EventTests.swift */,
+				9F60491F2FC979B700190D5C /* CSBinaryEventTests.swift */,
 				D8F38D4F2E94CCD300C4281E /* ClickstreamNetworkOptionsTests.swift */,
 				D8D18A372F2C9468000146A6 /* ClickstreamEventTests.swift */,
 			);
@@ -1101,6 +1107,7 @@
 				D8A7F7CF2EC6B60900DFC9AE /* Interfaces */,
 				D8A7F7BB2EC5EFE200DFC9AE /* Courier */,
 				BDE467B92A5BD72000BFA976 /* Event.swift */,
+				9F60491C2FC9781700190D5C /* CSBinaryEvent.swift */,
 				BDE467BB2A5BD72000BFA976 /* EventBatch.swift */,
 				BDE467BA2A5BD72000BFA976 /* ClickstreamEvent.swift */,
 			);
@@ -1684,6 +1691,7 @@
 				BD6BDB8829FBC1360006B04A /* HealthAnalysisEvent.swift in Sources */,
 				9A0BBA882BC3A59300F7DC01 /* URLRequest+Equality.swift in Sources */,
 				D8A7F7CD2EC6B5F800DFC9AE /* EventBatchPersistable.swift in Sources */,
+				9F60491D2FC9781700190D5C /* CSBinaryEvent.swift in Sources */,
 				BD6BDB6C29FBC1360006B04A /* FilterTextFieldTableViewCell.swift in Sources */,
 				BDE467FF2A5BD72000BFA976 /* Heartbeat.swift in Sources */,
 				BDE468652A5BD72000BFA976 /* EventBatchProcessor.swift in Sources */,
@@ -1718,6 +1726,7 @@
 				D859DC4D2E9F52B7008D900F /* ClickstreamCourierConfigTests.swift in Sources */,
 				D859DC482E9F5224008D900F /* ClickstreamCourierUserCredentialsTests.swift in Sources */,
 				BD6BDB9F29FBC1360006B04A /* CSCommonPropertiesDTO.swift in Sources */,
+				9F60491E2FC9781700190D5C /* CSBinaryEvent.swift in Sources */,
 				D8A7F7F62EC6D72D00DFC9AE /* ClickstreamCourierRetryPolicy.swift in Sources */,
 				BDE467752A5BD24500BFA976 /* BatchSizeRegulatorMock.swift in Sources */,
 				BDE4680E2A5BD72000BFA976 /* NetworkReachability.swift in Sources */,
@@ -1813,6 +1822,7 @@
 				D8E4B89C2EA9EF940001D3D6 /* CourierHandlerTests.swift in Sources */,
 				BDE467832A5BD24500BFA976 /* NetworkReachabilityMock.swift in Sources */,
 				D8F38D902E9CB08300C4281E /* QoS+Int.swift in Sources */,
+				9F6049202FC979B700190D5C /* CSBinaryEventTests.swift in Sources */,
 				D8F38D502E94CCD300C4281E /* ClickstreamNetworkOptionsTests.swift in Sources */,
 				BDE4681C2A5BD72000BFA976 /* ClickStreamConstraints.swift in Sources */,
 				BDE468702A5BD72000BFA976 /* DatabaseHandler.swift in Sources */,

--- a/ClickstreamTests/Core/Entities/CSBinaryEventTests.swift
+++ b/ClickstreamTests/Core/Entities/CSBinaryEventTests.swift
@@ -1,0 +1,57 @@
+//
+//  CSBinaryEventTests.swift
+//  ClickstreamTests
+//
+//  Copyright © 2026 Gojek. All rights reserved.
+//
+
+@testable import Clickstream
+import XCTest
+
+class CSBinaryEventTests: XCTestCase {
+
+    func testInitializationSetsAutoFields() {
+        let before = Date()
+        let event = CSBinaryEvent(type: "gopay-container-component", encodedData: "dGVzdA==")
+        let after = Date()
+
+        XCTAssertFalse(event.guid.isEmpty)
+        XCTAssertGreaterThanOrEqual(event.timestamp, before)
+        XCTAssertLessThanOrEqual(event.timestamp, after)
+    }
+
+    func testInitializationWithRequiredFields() {
+        let event = CSBinaryEvent(type: "gopay-container-page", encodedData: "dGVzdA==")
+
+        XCTAssertEqual(event.type, "gopay-container-page")
+        XCTAssertEqual(event.eventName, "gopay-container-page")
+        XCTAssertEqual(event.encodedData, "dGVzdA==")
+        XCTAssertNil(event.product)
+    }
+
+    func testInitializationWithProduct() {
+        let event = CSBinaryEvent(type: "gopay-container-component", encodedData: "dGVzdA==", product: "gopay")
+
+        XCTAssertEqual(event.product, "gopay")
+    }
+
+    func testEventNameDefaultsToTypeWhenNotProvided() {
+        let event = CSBinaryEvent(type: "gopay-container-page", encodedData: "dGVzdA==")
+
+        XCTAssertEqual(event.eventName, event.type)
+    }
+
+    func testEventNameCanBeSetIndependentlyFromType() {
+        let event = CSBinaryEvent(type: "gopay-container-page", encodedData: "dGVzdA==", eventName: "page-view")
+
+        XCTAssertEqual(event.type, "gopay-container-page")
+        XCTAssertEqual(event.eventName, "page-view")
+    }
+
+    func testEachInstanceHasUniqueGuid() {
+        let first = CSBinaryEvent(type: "type", encodedData: "dGVzdA==")
+        let second = CSBinaryEvent(type: "type", encodedData: "dGVzdA==")
+
+        XCTAssertNotEqual(first.guid, second.guid)
+    }
+}

--- a/ClickstreamTests/EventProcessorTests/CourierEventProcessorTest.swift
+++ b/ClickstreamTests/EventProcessorTests/CourierEventProcessorTest.swift
@@ -13,6 +13,7 @@ import SwiftProtobuf
 class CourierEventProcessorTest: XCTestCase {
     
     private var mockQueue: SerialQueue!
+    private let dbQueueMock = SerialQueue(label: "test.courier.db.queue", qos: .utility, attributes: .concurrent)
     private var mockClassifier: MockEventClassifier!
     private var mockWarehouser: CourierEventWarehouser!
     private var mockSampler: EventSampler!
@@ -35,7 +36,7 @@ class CourierEventProcessorTest: XCTestCase {
 
         networkOptions = ClickstreamNetworkOptions()
         batchSizeRegulator = CourierBatchSizeRegulator()
-        persitance = DefaultDatabaseDAO<CourierEvent>(database: db, performOnQueue: mockQueue)
+        persitance = DefaultDatabaseDAO<CourierEvent>(database: db, performOnQueue: dbQueueMock)
         
         courierNetworkBuilder = MockNetworkBuilder()
         courierBatchCreator = CourierEventBatchCreator(with: courierNetworkBuilder, performOnQueue: mockQueue, healthTrackingConfig: .init())
@@ -152,6 +153,52 @@ class CourierEventProcessorTest: XCTestCase {
 //        
 //        XCTAssertNotNil(courierEventProcessor)
 //    }
+
+    func testCreateBinaryEventWithValidBase64() {
+        let payload = "hello binary".data(using: .utf8)!
+        let base64 = payload.base64EncodedString()
+        let event = CSBinaryEvent(type: "Gopay-Container-Page", encodedData: base64, product: "gopay")
+
+        courierEventProcessor.createBinaryEvent(event: event)
+
+        let expectation = XCTestExpectation(description: "binary event stored")
+        mockQueue.async {
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 2.0)
+    }
+
+    func testCreateBinaryEventTypeIsLowercased() {
+        let event = CSBinaryEvent(type: "Gopay-Container-Page", encodedData: "dGVzdA==")
+
+        XCTAssertEqual(event.type.lowercased(), "gopay-container-page")
+    }
+
+    func testCreateBinaryEventWithInvalidBase64IsDropped() {
+        let event = CSBinaryEvent(type: "gopay-container-component", encodedData: "not-valid-base64!!!")
+
+        courierEventProcessor.createBinaryEvent(event: event)
+
+        let expectation = XCTestExpectation(description: "invalid binary event handled")
+        mockQueue.async {
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 2.0)
+    }
+
+    func testCreateBinaryEventWithNilClassificationIsDropped() {
+        mockClassifier.classificationResult = nil
+        let payload = "data".data(using: .utf8)!
+        let event = CSBinaryEvent(type: "gopay-container-page", encodedData: payload.base64EncodedString())
+
+        courierEventProcessor.createBinaryEvent(event: event)
+
+        let expectation = XCTestExpectation(description: "nil classification handled")
+        mockQueue.async {
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 2.0)
+    }
 }
 
 class MockEventClassifier: EventClassifier {

--- a/ClickstreamTests/EventProcessorTests/EventProcessorTest.swift
+++ b/ClickstreamTests/EventProcessorTests/EventProcessorTest.swift
@@ -172,6 +172,67 @@ class EventProcessorTest: XCTestCase {
         
         XCTAssertTrue(processor.sampleEvent(event: testEvent))
     }
+
+    func testCreateBinaryEventWithValidBase64() {
+        let payload = "hello binary".data(using: .utf8)!
+        let base64 = payload.base64EncodedString()
+        let event = CSBinaryEvent(type: "Gopay-Container-Component", encodedData: base64, product: "gopay")
+
+        eventProcessor.createBinaryEvent(event: event)
+
+        let expectation = XCTestExpectation(description: "binary event stored")
+        processorQueueMock.async {
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 2.0)
+    }
+
+    func testCreateBinaryEventTypeIsLowercased() {
+        let payload = "hello".data(using: .utf8)!
+        let event = CSBinaryEvent(type: "Gopay-Container-Page", encodedData: payload.base64EncodedString())
+
+        XCTAssertEqual(event.type, "Gopay-Container-Page")
+        XCTAssertEqual(event.type.lowercased(), "gopay-container-page")
+    }
+
+    func testCreateBinaryEventEventNameDefaultsToType() {
+        let event = CSBinaryEvent(type: "gopay-container-page", encodedData: "dGVzdA==")
+
+        XCTAssertEqual(event.eventName, "gopay-container-page")
+    }
+
+    func testCreateBinaryEventWithCustomEventName() {
+        let event = CSBinaryEvent(type: "gopay-container-page", encodedData: "dGVzdA==", eventName: "page-view")
+
+        XCTAssertEqual(event.type, "gopay-container-page")
+        XCTAssertEqual(event.eventName, "page-view")
+    }
+
+    func testCreateBinaryEventWithInvalidBase64IsDropped() {
+        let event = CSBinaryEvent(type: "gopay-container-component", encodedData: "not-valid-base64!!!")
+
+        eventProcessor.createBinaryEvent(event: event)
+
+        let expectation = XCTestExpectation(description: "invalid binary event handled")
+        processorQueueMock.async {
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 2.0)
+    }
+
+    func testCreateBinaryEventWithNilClassificationIsDropped() {
+        mockClassifier.classificationResult = nil
+        let payload = "data".data(using: .utf8)!
+        let event = CSBinaryEvent(type: "gopay-container-component", encodedData: payload.base64EncodedString())
+
+        eventProcessor.createBinaryEvent(event: event)
+
+        let expectation = XCTestExpectation(description: "nil classification handled")
+        processorQueueMock.async {
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 2.0)
+    }
 }
 
 class MockEventSampler: EventSampler {

--- a/Sources/Clickstream/Core/Domain/Entities/CSBinaryEvent.swift
+++ b/Sources/Clickstream/Core/Domain/Entities/CSBinaryEvent.swift
@@ -1,0 +1,30 @@
+//
+//  CSBinaryEvent.swift
+//  Clickstream
+//
+//  Copyright © 2026 Gojek. All rights reserved.
+//
+
+import Foundation
+
+public struct CSBinaryEvent {
+
+    public let guid: String
+    public let timestamp: Date
+    public let type: String
+    public let eventName: String
+    public let encodedData: String
+    public let product: String?
+
+    public init(type: String,
+                encodedData: String,
+                product: String? = nil,
+                eventName: String? = nil) {
+        self.guid = UUID().uuidString
+        self.timestamp = Date()
+        self.type = type
+        self.eventName = eventName ?? type
+        self.encodedData = encodedData
+        self.product = product
+    }
+}

--- a/Sources/Clickstream/Core/Interface/ClickStream.swift
+++ b/Sources/Clickstream/Core/Interface/ClickStream.swift
@@ -189,6 +189,13 @@ public final class Clickstream {
     public func trackEventViaCourier(with event: ClickstreamEvent) {
         courierEventProcessor.createEvent(event: event, isUserAuthenticated: isUserAuthenticated)
     }
+
+    /// Tracks a binary event received from a web bridge.
+    /// The encoded protobuf payload is forwarded as-is via the websocket channel.
+    /// - Parameter event: A `CSBinaryEvent` carrying the base64-encoded proto payload and its type.
+    public func trackBinaryEvent(_ event: CSBinaryEvent) {
+        socketEventProcessor.createBinaryEvent(event: event)
+    }
     
     /// Initializes an instance of the API with the given configurations.
     /// Returns a new Clickstream instance API object. This allows you to create one instance only.

--- a/Sources/Clickstream/EventProcessor/Core/Courier/CourierEventProcessor.swift
+++ b/Sources/Clickstream/EventProcessor/Core/Courier/CourierEventProcessor.swift
@@ -159,7 +159,8 @@ final class CourierEventProcessor: EventProcessor {
                 guid: event.guid,
                 timestamp: event.timestamp,
                 type: classification,
-                eventProtoData: csEvent.serializedData()
+                eventProtoData: csEvent.serializedData(),
+                expiryTime:  Date()
             )
         } catch {
             return nil

--- a/Sources/Clickstream/EventProcessor/Core/Courier/CourierEventProcessor.swift
+++ b/Sources/Clickstream/EventProcessor/Core/Courier/CourierEventProcessor.swift
@@ -122,6 +122,49 @@ final class CourierEventProcessor: EventProcessor {
     private func isExslusiveEvent(_ event: ClickstreamEvent) -> Bool {
         !networkOptions.isWebsocketEnabled || networkOptions.courierExclusiveEventTypes.contains(event.messageName)
     }
+
+    func createBinaryEvent(event: CSBinaryEvent) {
+        self.serialQueue.async { [weak self] in
+            guard let checkedSelf = self else { return }
+            if let eventToStore = checkedSelf.constructBinaryEvent(event: event) {
+                checkedSelf.eventWarehouser.store(eventToStore)
+            }
+        }
+    }
+
+    private func constructBinaryEvent(event: CSBinaryEvent) -> CourierEvent? {
+        let placeholder = ClickstreamEvent(
+            guid: event.guid,
+            timeStamp: event.timestamp,
+            message: nil,
+            eventName: event.eventName,
+            eventData: Data(),
+            product: event.product ?? ""
+        )
+        guard let classification = classifier.getClassification(event: placeholder) else { return nil }
+        guard let decodedData = Data(base64Encoded: event.encodedData) else { return nil }
+
+        do {
+            let csEvent = Odpf_Raccoon_Event.with {
+                $0.eventBytes = decodedData
+                $0.type = event.type.lowercased()
+                $0.eventName = event.eventName
+                $0.product = event.product ?? ""
+                $0.eventTimestamp = Google_Protobuf_Timestamp(date: event.timestamp)
+                $0.isExclusive = true
+                $0.appVersion = Clickstream.appVersion
+                $0.platform = .ios
+            }
+            return try CourierEvent(
+                guid: event.guid,
+                timestamp: event.timestamp,
+                type: classification,
+                eventProtoData: csEvent.serializedData()
+            )
+        } catch {
+            return nil
+        }
+    }
     
     private func trackHealthEvent(event: ClickstreamEvent, healthEventName: HealthEvents, reason: String) {
         if let classification = self.classifier.getClassification(event: event), classification == "realTime" {

--- a/Sources/Clickstream/EventProcessor/Core/EventProcessor.swift
+++ b/Sources/Clickstream/EventProcessor/Core/EventProcessor.swift
@@ -11,6 +11,7 @@ import SwiftProtobuf
 
 protocol EventProcessorInput {
     func createEvent(event: ClickstreamEvent, isUserAuthenticated: Bool)
+    func createBinaryEvent(event: CSBinaryEvent)
 }
 
 protocol EventProcessorOutput { }
@@ -103,6 +104,49 @@ final class DefaultEventProcessor: EventProcessor {
                              timestamp: event.timeStamp,
                              type: classification,
                              eventProtoData: csEvent.serializedData())
+        } catch {
+            return nil
+        }
+    }
+
+    func createBinaryEvent(event: CSBinaryEvent) {
+        self.serialQueue.async { [weak self] in
+            guard let checkedSelf = self else { return }
+            if let eventToStore = checkedSelf.constructBinaryEvent(event: event) {
+                checkedSelf.eventWarehouser.store(eventToStore)
+            }
+        }
+    }
+
+    private func constructBinaryEvent(event: CSBinaryEvent) -> Event? {
+        let placeholder = ClickstreamEvent(
+            guid: event.guid,
+            timeStamp: event.timestamp,
+            message: nil,
+            eventName: event.eventName,
+            eventData: Data(),
+            product: event.product ?? ""
+        )
+        guard let classification = classifier.getClassification(event: placeholder) else { return nil }
+        guard let decodedData = Data(base64Encoded: event.encodedData) else { return nil }
+
+        do {
+            let csEvent = Odpf_Raccoon_Event.with {
+                $0.eventBytes = decodedData
+                $0.type = event.type.lowercased()
+                $0.eventName = event.eventName
+                $0.product = event.product ?? ""
+                $0.eventTimestamp = Google_Protobuf_Timestamp(date: event.timestamp)
+                $0.isExclusive = true
+                $0.appVersion = Clickstream.appVersion
+                $0.platform = .ios
+            }
+            return try Event(
+                guid: event.guid,
+                timestamp: event.timestamp,
+                type: classification,
+                eventProtoData: csEvent.serializedData()
+            )
         } catch {
             return nil
         }


### PR DESCRIPTION
Card: https://go-jek.atlassian.net/browse/CNTNRSDK-739
Production readiness Card: https://go-jek.atlassian.net/browse/CNTNRSDK-824.
These changes were already merged and tested  on https://github.com/gojek/clickstream-ios/tree/digital_identity_ios_12
previous MR: https://github.com/gojek/clickstream-ios/pull/139

**Background**
Webapps rendered inside GoPayWebkit send analytics payloads to native via the web bridge. In the older setup, the host app was Flutter-based, so analytics from this bridge were forwarded through Flutter and tracked using the clickstream-flutter SDK.
This use case is for the native iOS SDK path, where tracking should happen directly in clickstream-ios without relying on Flutter as an intermediary.

**Problem**
There was no dedicated native iOS API to track binary analytics payloads coming from the bridge. Existing APIs such as trackEvent / trackEventViaWebsocket require a fully constructed ClickstreamEvent with a deserialized protobuf message, which is not available in this bridge flow.

**Solution**
Introduce CSBinaryEvent as a public model for bridge-originated binary analytics payloads. It carries:

event type
base64-encoded payload (encodedData)
optional product
optional eventName (defaults to type for backward compatibility)
Expose trackBinaryEvent(_ event: CSBinaryEvent) in Clickstream and route it via the websocket processor path (socketEventProcessor), which is already established and reliable for delivery in this integration.
