### PR TITLE
fix: concurrent thread safety crash in dictionaries in EV

### DIFF
--- a/Sources/EventVisualizer/src/Helpers/EventsHelper.swift
+++ b/Sources/EventVisualizer/src/Helpers/EventsHelper.swift
@@ -8,6 +8,7 @@
 
 import UIKit
 import Foundation
+import os
 
 struct ClickstreamConnectionStatusView {
     var statusLabel: UILabel
@@ -20,27 +21,52 @@ final public class EventsHelper {
     
     /// singleton variable
     public static let shared: EventsHelper = EventsHelper()
-    
+
+    /// Guards every access to `_eventsCaptured` and `stateByEventGuid`.
+    /// Writes arrive on multiple background serial queues (event processing,
+    /// scheduling, network, retry) while reads happen on the main thread from
+    /// the visualizer UI, so all access must be serialized. Allocated via a
+    /// stable pointer to avoid the `&property` inout pitfall; the singleton
+    /// lives for the process lifetime so it is never deallocated.
+    private let unfairLock: os_unfair_lock_t = {
+        let lock = os_unfair_lock_t.allocate(capacity: 1)
+        lock.initialize(to: os_unfair_lock())
+        return lock
+    }()
+
+    private func withLock<T>(_ body: () -> T) -> T {
+        os_unfair_lock_lock(unfairLock)
+        defer { os_unfair_lock_unlock(unfairLock) }
+        return body()
+    }
+
+    private var _eventsCaptured: [EventData] = []
+
     /// used for capturing the events sent by Clickstream
-    public var eventsCaptured: [EventData] = []
+    public var eventsCaptured: [EventData] {
+        get { withLock { _eventsCaptured } }
+        set { withLock { _eventsCaptured = newValue } }
+    }
     private var stateByEventGuid: [String: String] = [:]
-    
+
     public var clickstreamConnectionState: Clickstream.ConnectionState {
         return Clickstream.getInstance()?.clickstreamConnectionState ?? .failed
     }
     
     /// returns the state of the event given the eventGuid
     public func getState(of providedEventGuid: String) -> String {
-        if let cachedState = stateByEventGuid[providedEventGuid] {
-            return cachedState
-        }
+        return withLock {
+            if let cachedState = stateByEventGuid[providedEventGuid] {
+                return cachedState
+            }
 
-        if let foundIndex = indexOfEvent(with: providedEventGuid) {
-            let state = EventsHelper.shared.eventsCaptured[foundIndex].state.description
-            stateByEventGuid[providedEventGuid] = state
-            return state
+            if let foundIndex = indexOfEvent(with: providedEventGuid) {
+                let state = _eventsCaptured[foundIndex].state.description
+                stateByEventGuid[providedEventGuid] = state
+                return state
+            }
+            return ""
         }
-        return ""
     }
     
     public func startCapturing() {
@@ -55,8 +81,10 @@ final public class EventsHelper {
         #endif
     }
     public func clearData() {
-        EventsHelper.shared.eventsCaptured = []
-        stateByEventGuid = [:]
+        withLock {
+            _eventsCaptured = []
+            stateByEventGuid = [:]
+        }
     }
     
     @available(iOS 13.0, *)
@@ -94,13 +122,15 @@ extension EventsHelper: EventStateViewable {
             displaySummary: summary
         )
 
-        /// all events sent by Clickstream is stored here in an array
-        EventsHelper.shared.eventsCaptured.append(eventWithSummary)
+        withLock {
+            /// all events sent by Clickstream is stored here in an array
+            _eventsCaptured.append(eventWithSummary)
 
-        if let eventGuid = summary?.eventGuid {
-            stateByEventGuid[eventGuid] = event.state.description
-        } else if let eventGuid = EventDisplayFieldReader.eventGuid(from: event.msg) {
-            stateByEventGuid[eventGuid] = event.state.description
+            if let eventGuid = summary?.eventGuid {
+                stateByEventGuid[eventGuid] = event.state.description
+            } else if let eventGuid = EventDisplayFieldReader.eventGuid(from: event.msg) {
+                stateByEventGuid[eventGuid] = event.state.description
+            }
         }
     }
     
@@ -114,40 +144,44 @@ extension EventsHelper: EventStateViewable {
     ///   - eventBatch: this is the eventBatchGuid for a particular event batch
     ///   - state: this is the state in which the event is in
     public func updateStatus(providedEventGuid: String? = nil, eventBatchID eventBatch: String? = nil, state: EventState) {
-        if let providedEventGuid = providedEventGuid,
-            let foundIndex = indexOfEvent(with: providedEventGuid),
-            foundIndex < EventsHelper.shared.eventsCaptured.count {
-            
-            EventsHelper.shared.eventsCaptured[foundIndex].state = state
-            stateByEventGuid[providedEventGuid] = state.description
-            if let eventBatch = eventBatch {
-                EventsHelper.shared.eventsCaptured[foundIndex].batchId = eventBatch
-            }
-        } else if let eventBatch = eventBatch {
-            let foundIndexs = indexOfEventBatch(with: eventBatch)
-            for eventIndex in foundIndexs {
-                if eventIndex < EventsHelper.shared.eventsCaptured.count {
-                    EventsHelper.shared.eventsCaptured[eventIndex].state = state
-                    if let eventGuid = EventsHelper.shared.eventsCaptured[eventIndex].displaySummary?.eventGuid ?? EventDisplayFieldReader.eventGuid(from: EventsHelper.shared.eventsCaptured[eventIndex].msg) {
-                        stateByEventGuid[eventGuid] = state.description
+        withLock {
+            if let providedEventGuid = providedEventGuid,
+                let foundIndex = indexOfEvent(with: providedEventGuid),
+                foundIndex < _eventsCaptured.count {
+
+                _eventsCaptured[foundIndex].state = state
+                stateByEventGuid[providedEventGuid] = state.description
+                if let eventBatch = eventBatch {
+                    _eventsCaptured[foundIndex].batchId = eventBatch
+                }
+            } else if let eventBatch = eventBatch {
+                let foundIndexs = indexOfEventBatch(with: eventBatch)
+                for eventIndex in foundIndexs {
+                    if eventIndex < _eventsCaptured.count {
+                        _eventsCaptured[eventIndex].state = state
+                        if let eventGuid = _eventsCaptured[eventIndex].displaySummary?.eventGuid ?? EventDisplayFieldReader.eventGuid(from: _eventsCaptured[eventIndex].msg) {
+                            stateByEventGuid[eventGuid] = state.description
+                        }
                     }
                 }
             }
         }
     }
 
+    /// Callers must already hold `unfairLock`.
     private func indexOfEvent(with eventGuid: String) -> Int? {
-        for (index, event) in EventsHelper.shared.eventsCaptured.enumerated() {
+        for (index, event) in _eventsCaptured.enumerated() {
             if let currentEventGuid = event.displaySummary?.eventGuid ?? EventDisplayFieldReader.eventGuid(from: event.msg), currentEventGuid == eventGuid {
                 return index
             }
         }
         return nil
     }
-    
+
+    /// Callers must already hold `unfairLock`.
     private func indexOfEventBatch(with eventBatchGuid: String) -> [Int] {
         var foundEventsArray: [Int] = []
-        for (index, event) in EventsHelper.shared.eventsCaptured.enumerated() {
+        for (index, event) in _eventsCaptured.enumerated() {
             if event.batchId == eventBatchGuid {
                 foundEventsArray.append(index)
             }


### PR DESCRIPTION
## Description

We noticed a few crashes during local development with ClickStream + EventVisualiser (aka EV) enabled.

This MR attempts fixes for those crashes by adding thread safe code/checks around dictionary updates.

Here's a sample crash we received

<img width="1336" height="745" alt="EventsHelper crash" src="https://github.com/user-attachments/assets/4305972a-9161-41e2-be12-3a3316c311be" />

## Summary of the fix

Root cause: `eventsCaptured` (array) and `stateByEventGuid` (dict) were mutated from 8+ background serial queues while the visualizer UI read them on the main thread. Concurrent access corrupts the collections' COW backing storage — which is exactly what we see in the crash screenshot above -[__NSCFNumber count]: unrecognized selector ... 0x8000000000000000 crash is (a mangled pointer, not a logic error). Line 122 was just where it surfaced.

- Added a process-lifetime `os_unfair_lock_t` + a `withLock` helper.
- `eventsCaptured` is now a computed public var backed by private `_eventsCaptured`, with get/set behind the lock — this closes the direct main-thread read at `EventVisualizerLandingViewModel.swift:262`, which a purely internal lock would have missed.
- `getState`, `sendEvent`, `updateStatus`, `clearData` all mutate/read under the lock.
- `indexOfEvent` / `indexOfEventBatch` stay lock-free by contract (`os_unfair_lock` isn't recursive) and are only ever called from within a `withLock` block.

#### Notes:
- The summary precompute in sendEvent is intentionally kept outside the lock (it touches no shared state) to keep the critical section short.
- This makes each operation atomic. A caller doing read-modify-write across two separate calls still isn't atomic as a unit — but none of the current call sites do that, so it's fine.