### PR TITLE
Fix Courier Retry Mechanism crash

### DIFF
--- a/Sources/Clickstream/NetworkManager/Courier/CourierRetryMechanism.swift
+++ b/Sources/Clickstream/NetworkManager/Courier/CourierRetryMechanism.swift
@@ -22,6 +22,13 @@ final class CourierRetryMechanism: Retryable {
     private var networkServiceState: ConnectableState?
     private var persistence: DefaultDatabaseDAO<CourierEventRequest>
     private var retryTimer: DispatchSourceTimer?
+    /// Serializes every access to `retryTimer`. The timer is created, cancelled and
+    /// nil-ed from several execution contexts — the Courier connection-status callback
+    /// thread (`connectionStatusListener`), the reachability / teardown paths
+    /// (`stopTracking` runs from `deinit`) and the timer's own event handler on
+    /// `performQueue`. Without this lock those accesses race, over-releasing the
+    /// `DispatchSourceTimer` and crashing in `_os_object_retain`.
+    private let retryTimerLock = NSLock()
     private var identifiers: ClickstreamClientIdentifiers?
     private var authProvider: IConnectionServiceProvider?
     private var pubSubAnalytics: ICourierEventHandler?
@@ -441,18 +448,28 @@ extension CourierRetryMechanism {
     }
     
     private func startObservingFailedBatches() {
+        retryTimerLock.lock()
+        defer { retryTimerLock.unlock() }
+
         guard retryTimer == nil else { return }
-        retryTimer = DispatchSource.makeTimerSource(flags: .strict, queue: performQueue)
-        retryTimer?.schedule(deadline: .now() + Clickstream.courierConfigurations.maxRequestAckTimeout,
-                             repeating: Clickstream.courierConfigurations.maxRequestAckTimeout)
-        retryTimer?.setEventHandler(handler: { [weak self] in
+        // Build and start the timer atomically under the lock so a concurrent
+        // stopObservingFailedBatches() can never release a half-configured or
+        // still-suspended source.
+        let timer = DispatchSource.makeTimerSource(flags: .strict, queue: performQueue)
+        timer.schedule(deadline: .now() + Clickstream.courierConfigurations.maxRequestAckTimeout,
+                       repeating: Clickstream.courierConfigurations.maxRequestAckTimeout)
+        timer.setEventHandler(handler: { [weak self] in
             guard let checkedSelf = self else { return }
             checkedSelf.retryFailedBatches()
         })
-        retryTimer?.resume()
+        retryTimer = timer
+        timer.resume()
     }
-    
+
     private func stopObservingFailedBatches() {
+        retryTimerLock.lock()
+        defer { retryTimerLock.unlock() }
+
         retryTimer?.cancel()
         retryTimer = nil
     }


### PR DESCRIPTION
Guard all access to retryTimer in CourierRetryMechanism with an NSLock, and build + start the timer atomically before assigning it to the property.

Why
Crashlytics reported a crash on the com.clickstream.courier.network thread:

Crashed: com.clickstream.courier.network
0  libdispatch.dylib   _os_object_retain + 68
1  CourierRetryMechanism.retryFailedBatches() (CourierRetryMechanism.swift:456)
2  closure #1 in CourierRetryMechanism.startObservingFailedBatches() (CourierRetryMechanism.swift:450)
retryTimer (a DispatchSourceTimer) was a non-synchronized stored property mutated from three uncoordinated execution contexts:

the Courier connection-status callback thread (connectionStatusListener → start/stopObservingFailedBatches)
the teardown path (stopTracking(), which runs from deinit)
the timer's own event handler running on performQueue
When one thread released and nil-ed the timer while another was retaining/using it, _os_object_retain operated on freed memory → use-after-free crash. There was also a narrower window where stop could run between makeTimerSource(...) and resume(), releasing a still-suspended source.

How
Added private let retryTimerLock = NSLock().
startObservingFailedBatches() now creates, schedules, and resume()s a local timer under the lock, assigning to retryTimer only once fully configured.
stopObservingFailedBatches() now cancels + nils under the same lock.
This makes create-vs-cancel mutually exclusive, so the dispatch source can never be freed mid-access, and closes the suspended-source release window.

Why a lock instead of serializing on performQueue
stopObservingFailedBatches() is reachable from deinit (via stopTracking()), where dispatching async onto performQueue and capturing self is unsafe. A synchronous lock is correct in deinit. No deadlock risk: timer.resume() does not invoke the event handler synchronously, so no lock is re-entered.

Testing
Static reasoning + code review of all retryTimer call sites (no path takes the lock recursively).
Recommend: run the SDK with Thread Sanitizer enabled and exercise connection flap / background-foreground while retries are active.