### PR TITLE
Route `trackBinaryEvent` through CourierEventProcessor

### DIFF
--- a/ClickstreamTests/EventProcessorTests/CourierEventProcessorTest.swift
+++ b/ClickstreamTests/EventProcessorTests/CourierEventProcessorTest.swift
@@ -159,7 +159,7 @@ class CourierEventProcessorTest: XCTestCase {
         let base64 = payload.base64EncodedString()
         let event = CSBinaryEvent(type: "Gopay-Container-Page", encodedData: base64, product: "gopay")
 
-        courierEventProcessor.createBinaryEvent(event: event)
+        courierEventProcessor.createBinaryEvent(event: event, isUserAuthenticated: false)
 
         let expectation = XCTestExpectation(description: "binary event stored")
         mockQueue.async {
@@ -177,7 +177,7 @@ class CourierEventProcessorTest: XCTestCase {
     func testCreateBinaryEventWithInvalidBase64IsDropped() {
         let event = CSBinaryEvent(type: "gopay-container-component", encodedData: "not-valid-base64!!!")
 
-        courierEventProcessor.createBinaryEvent(event: event)
+        courierEventProcessor.createBinaryEvent(event: event, isUserAuthenticated: false)
 
         let expectation = XCTestExpectation(description: "invalid binary event handled")
         mockQueue.async {
@@ -191,7 +191,7 @@ class CourierEventProcessorTest: XCTestCase {
         let payload = "data".data(using: .utf8)!
         let event = CSBinaryEvent(type: "gopay-container-page", encodedData: payload.base64EncodedString())
 
-        courierEventProcessor.createBinaryEvent(event: event)
+        courierEventProcessor.createBinaryEvent(event: event, isUserAuthenticated: false)
 
         let expectation = XCTestExpectation(description: "nil classification handled")
         mockQueue.async {

--- a/ClickstreamTests/EventProcessorTests/EventProcessorTest.swift
+++ b/ClickstreamTests/EventProcessorTests/EventProcessorTest.swift
@@ -178,7 +178,7 @@ class EventProcessorTest: XCTestCase {
         let base64 = payload.base64EncodedString()
         let event = CSBinaryEvent(type: "Gopay-Container-Component", encodedData: base64, product: "gopay")
 
-        eventProcessor.createBinaryEvent(event: event)
+        eventProcessor.createBinaryEvent(event: event, isUserAuthenticated: false)
 
         let expectation = XCTestExpectation(description: "binary event stored")
         processorQueueMock.async {
@@ -211,7 +211,7 @@ class EventProcessorTest: XCTestCase {
     func testCreateBinaryEventWithInvalidBase64IsDropped() {
         let event = CSBinaryEvent(type: "gopay-container-component", encodedData: "not-valid-base64!!!")
 
-        eventProcessor.createBinaryEvent(event: event)
+        eventProcessor.createBinaryEvent(event: event, isUserAuthenticated: false)
 
         let expectation = XCTestExpectation(description: "invalid binary event handled")
         processorQueueMock.async {
@@ -225,7 +225,7 @@ class EventProcessorTest: XCTestCase {
         let payload = "data".data(using: .utf8)!
         let event = CSBinaryEvent(type: "gopay-container-component", encodedData: payload.base64EncodedString())
 
-        eventProcessor.createBinaryEvent(event: event)
+        eventProcessor.createBinaryEvent(event: event, isUserAuthenticated: false)
 
         let expectation = XCTestExpectation(description: "nil classification handled")
         processorQueueMock.async {

--- a/Sources/Clickstream/Core/Domain/Entities/CSBinaryEvent.swift
+++ b/Sources/Clickstream/Core/Domain/Entities/CSBinaryEvent.swift
@@ -28,3 +28,24 @@ public struct CSBinaryEvent {
         self.product = product
     }
 }
+
+extension CSBinaryEvent {
+
+    func shouldTrackOnCourier(isUserLoggedIn: Bool, networkOptions: ClickstreamNetworkOptions) -> Bool {
+        let isUserEligible = isUserLoggedIn || networkOptions.isCourierPreAuthEnabled
+        let isCourierWhitelisted = networkOptions.courierEventTypes.contains(self.type)
+        let isCourierExclusive = networkOptions.courierExclusiveEventTypes.contains(self.type)
+
+        guard networkOptions.isCourierEnabled && isUserEligible else { return false }
+        if networkOptions.isWebsocketEnabled && !isCourierWhitelisted && !isCourierExclusive { return false }
+        return true
+    }
+
+    func shouldTrackOnWebsocket(isUserLoggedIn: Bool, networkOptions: ClickstreamNetworkOptions) -> Bool {
+        let isUserEligible = isUserLoggedIn || networkOptions.isCourierPreAuthEnabled
+        let isCourierExclusive = networkOptions.courierExclusiveEventTypes.contains(self.type)
+
+        if networkOptions.isCourierEnabled && isUserEligible && isCourierExclusive { return false }
+        return true
+    }
+}

--- a/Sources/Clickstream/Core/Interface/ClickStream.swift
+++ b/Sources/Clickstream/Core/Interface/ClickStream.swift
@@ -191,10 +191,11 @@ public final class Clickstream {
     }
 
     /// Tracks a binary event received from a web bridge.
-    /// The encoded protobuf payload is forwarded as-is via the websocket channel.
+    /// The encoded protobuf payload is forwarded via both the websocket and courier channels.
     /// - Parameter event: A `CSBinaryEvent` carrying the base64-encoded proto payload and its type.
     public func trackBinaryEvent(_ event: CSBinaryEvent) {
-        socketEventProcessor.createBinaryEvent(event: event)
+        socketEventProcessor.createBinaryEvent(event: event, isUserAuthenticated: isUserAuthenticated)
+        courierEventProcessor.createBinaryEvent(event: event, isUserAuthenticated: isUserAuthenticated)
     }
     
     /// Initializes an instance of the API with the given configurations.

--- a/Sources/Clickstream/EventProcessor/Core/Courier/CourierEventProcessor.swift
+++ b/Sources/Clickstream/EventProcessor/Core/Courier/CourierEventProcessor.swift
@@ -123,9 +123,10 @@ final class CourierEventProcessor: EventProcessor {
         !networkOptions.isWebsocketEnabled || networkOptions.courierExclusiveEventTypes.contains(event.messageName)
     }
 
-    func createBinaryEvent(event: CSBinaryEvent) {
+    func createBinaryEvent(event: CSBinaryEvent, isUserAuthenticated: Bool) {
         self.serialQueue.async { [weak self] in
             guard let checkedSelf = self else { return }
+            guard event.shouldTrackOnCourier(isUserLoggedIn: isUserAuthenticated, networkOptions: checkedSelf.networkOptions) else { return }
             if let eventToStore = checkedSelf.constructBinaryEvent(event: event) {
                 checkedSelf.eventWarehouser.store(eventToStore)
             }
@@ -160,7 +161,7 @@ final class CourierEventProcessor: EventProcessor {
                 timestamp: event.timestamp,
                 type: classification,
                 eventProtoData: csEvent.serializedData(),
-                expiryTime:  Date()
+                expiryTime: eventExpirationManager.getExpiration(for: placeholder)
             )
         } catch {
             return nil

--- a/Sources/Clickstream/EventProcessor/Core/EventProcessor.swift
+++ b/Sources/Clickstream/EventProcessor/Core/EventProcessor.swift
@@ -11,7 +11,7 @@ import SwiftProtobuf
 
 protocol EventProcessorInput {
     func createEvent(event: ClickstreamEvent, isUserAuthenticated: Bool)
-    func createBinaryEvent(event: CSBinaryEvent)
+    func createBinaryEvent(event: CSBinaryEvent, isUserAuthenticated: Bool)
 }
 
 protocol EventProcessorOutput { }
@@ -109,9 +109,12 @@ final class DefaultEventProcessor: EventProcessor {
         }
     }
 
-    func createBinaryEvent(event: CSBinaryEvent) {
+    func createBinaryEvent(event: CSBinaryEvent, isUserAuthenticated: Bool) {
         self.serialQueue.async { [weak self] in
             guard let checkedSelf = self else { return }
+            if checkedSelf.networkOptions.courierExclusiveEventsEnabled {
+                guard event.shouldTrackOnWebsocket(isUserLoggedIn: isUserAuthenticated, networkOptions: checkedSelf.networkOptions) else { return }
+            }
             if let eventToStore = checkedSelf.constructBinaryEvent(event: event) {
                 checkedSelf.eventWarehouser.store(eventToStore)
             }


### PR DESCRIPTION
## Route `trackBinaryEvent` through CourierEventProcessor

### Problem
`trackBinaryEvent` only dispatched to `socketEventProcessor`. Binary events from 
the WebView bridge were silently dropped on Courier (MQTT) transport.

Also, `constructBinaryEvent` used `expiryTime: Date()` — immediate expiry — 
causing binary events to be discarded on any courier retry.

### Changes
- **`CSBinaryEvent`** — Added `shouldTrackOnCourier` / `shouldTrackOnWebsocket` 
  routing methods using `event.type` as the `courierEventTypes` lookup key 
  (equivalent to `messageName` for proto events)
- **`EventProcessor` protocol** — `createBinaryEvent` now accepts 
  `isUserAuthenticated: Bool`, consistent with `createEvent`
- **`Clickstream.trackBinaryEvent`** — Dispatches to both processors with 
  transport routing, mirroring regular event behaviour
- **`CourierEventProcessor.constructBinaryEvent`** — Fixed `expiryTime: Date()` 
  → `eventExpirationManager.getExpiration(for:)`

### Related
- Ticket: https://go-jek.atlassian.net/browse/CNTNRSDK-848