### PR TITLE
Fix crash on Incoming Message class

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/gojek/courier-iOS.git",
       "state" : {
-        "revision" : "305fb309851e21a623deb61ea186e8a27bf81c8b",
-        "version" : "1.0.10"
+        "revision" : "9a56d572b256e87e76e7c8f210e2f68cef11dd48",
+        "version" : "1.0.20"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
         .package(url: "https://github.com/ashleymills/Reachability.swift.git", from: "5.0.0"),
         .package(url: "https://github.com/groue/GRDB.swift.git", from: "6.7.0"),
         .package(url: "https://github.com/daltoniam/Starscream.git", exact: "4.0.5"),
-        .package(url: "https://github.com/gojek/courier-iOS.git", exact: "1.0.10")
+        .package(url: "https://github.com/gojek/courier-iOS.git", exact: "1.0.20")
     ],
     targets: [
         .target(

--- a/Podfile
+++ b/Podfile
@@ -13,8 +13,8 @@ def clickstream_pods
   pod 'ReachabilitySwift', '5.2.3'
   pod 'GRDB.swift', '~> 6.7.0'
   pod 'Starscream', '4.0.5'
-  pod 'CourierCore', '1.0.17'
-  pod 'CourierMQTT', '1.0.17'
+  pod 'CourierCore', git: "https://github.com/gojek/courier-ios.git", tag: "1.0.20"
+  pod 'CourierMQTT', git: "https://github.com/gojek/courier-ios.git", tag: "1.0.20"
 end
 
 target 'Clickstream' do

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,20 +1,20 @@
 PODS:
-  - CourierCore (1.0.17)
-  - CourierMQTT (1.0.17):
-    - CourierCore (= 1.0.17)
-    - MQTTClientGJ (= 1.0.17)
+  - CourierCore (1.0.20)
+  - CourierMQTT (1.0.20):
+    - CourierCore (= 1.0.20)
+    - MQTTClientGJ (= 1.0.20)
     - ReachabilitySwift (>= 5.0.0)
   - GRDB.swift (6.7.0):
     - GRDB.swift/standard (= 6.7.0)
   - GRDB.swift/standard (6.7.0)
-  - MQTTClientGJ (1.0.17)
+  - MQTTClientGJ (1.0.20)
   - ReachabilitySwift (5.2.3)
   - Starscream (4.0.5)
   - SwiftProtobuf (1.30.0)
 
 DEPENDENCIES:
-  - CourierCore (= 1.0.17)
-  - CourierMQTT (= 1.0.17)
+  - CourierCore (from `https://github.com/gojek/courier-ios.git`, tag `1.0.20`)
+  - CourierMQTT (from `https://github.com/gojek/courier-ios.git`, tag `1.0.20`)
   - GRDB.swift (~> 6.7.0)
   - ReachabilitySwift (= 5.2.3)
   - Starscream (= 4.0.5)
@@ -22,23 +22,38 @@ DEPENDENCIES:
 
 SPEC REPOS:
   https://github.com/CocoaPods/Specs.git:
-    - CourierCore
-    - CourierMQTT
     - GRDB.swift
-    - MQTTClientGJ
     - ReachabilitySwift
     - Starscream
     - SwiftProtobuf
+  trunk:
+    - MQTTClientGJ
+
+EXTERNAL SOURCES:
+  CourierCore:
+    :git: https://github.com/gojek/courier-ios.git
+    :tag: 1.0.20
+  CourierMQTT:
+    :git: https://github.com/gojek/courier-ios.git
+    :tag: 1.0.20
+
+CHECKOUT OPTIONS:
+  CourierCore:
+    :git: https://github.com/gojek/courier-ios.git
+    :tag: 1.0.20
+  CourierMQTT:
+    :git: https://github.com/gojek/courier-ios.git
+    :tag: 1.0.20
 
 SPEC CHECKSUMS:
-  CourierCore: 5cd24d10a2e7de954eb794ca09f0fc96f0df814c
-  CourierMQTT: 09e8b1cff051f5fffca8fd4b8a759f480e9cc2e1
+  CourierCore: af9fad7c3722a9f38279f6e619606270a01f74bb
+  CourierMQTT: 3267bfcb511f1f58966e925ad5d534204dcc281a
   GRDB.swift: df2fdb0752e88383fc314e1e5d7c3a76d52054eb
-  MQTTClientGJ: d5a0c27304205cef4b52a5443666d532f954d131
+  MQTTClientGJ: c3ade198bab4bf90e6ad384f230c08496b2d5876
   ReachabilitySwift: 7f151ff156cea1481a8411701195ac6a984f4979
   Starscream: 97a24f0636451d134fbb932f2b15cefd89b1a040
   SwiftProtobuf: 3697407f0d5b23bedeba9c2eaaf3ec6fdff69349
 
-PODFILE CHECKSUM: baf8682db3b08640faa1562f08e97712b193f825
+PODFILE CHECKSUM: 6b82a4810a2e894e34651d0a0bbcce96d2d4a698
 
 COCOAPODS: 1.16.2

--- a/Sources/Clickstream/NetworkManager/Courier/Config/ClickstreamCourierConfig.swift
+++ b/Sources/Clickstream/NetworkManager/Courier/Config/ClickstreamCourierConfig.swift
@@ -29,6 +29,7 @@ public struct ClickstreamCourierClientConfig {
     public let courierInitCoreDataPersistenceContextEnabled: Bool
     public let courierQoSType: Int
     public let fixCxxDestructCrash: Bool
+    public let useSafeDeleteForNonSQLiteStore: Bool
     public let fixMultipleConnectionCrash: Bool
     public let courierConnectPolicy: ClickstreamCourierConnectPolicy
     public let courierInactivityPolicy: ClickstreamCourierInactivityPolicy
@@ -52,6 +53,7 @@ public struct ClickstreamCourierClientConfig {
         courierInitCoreDataPersistenceContextEnabled: Bool = false,
         courierQoSType: Int = 4,
         fixCxxDestructCrash: Bool = false,
+        useSafeDeleteForNonSQLiteStore: Bool = false,
         fixMultipleConnectionCrash: Bool = false,
         courierConnectPolicy: ClickstreamCourierConnectPolicy = .init(),
         courierInactivityPolicy: ClickstreamCourierInactivityPolicy = .init(),
@@ -74,6 +76,7 @@ public struct ClickstreamCourierClientConfig {
         self.courierInitCoreDataPersistenceContextEnabled = courierInitCoreDataPersistenceContextEnabled
         self.courierQoSType = courierQoSType
         self.fixCxxDestructCrash = fixCxxDestructCrash
+        self.useSafeDeleteForNonSQLiteStore = useSafeDeleteForNonSQLiteStore
         self.fixMultipleConnectionCrash = fixMultipleConnectionCrash
         self.courierConnectPolicy = courierConnectPolicy
         self.courierInactivityPolicy = courierInactivityPolicy

--- a/Sources/Clickstream/NetworkManager/Infrastructure/Courier/CourierHandler.swift
+++ b/Sources/Clickstream/NetworkManager/Infrastructure/Courier/CourierHandler.swift
@@ -95,7 +95,8 @@ extension DefaultCourierHandler {
                                           messagePersistenceTTLSeconds: TimeInterval(config.courierMessagePersistenceTTLSecs),
                                           messageCleanupInterval: TimeInterval(config.courierMessageCleanupInterval),
                                           shouldInitializeCoreDataPersistenceContext: config.courierInitCoreDataPersistenceContextEnabled,
-                                          fixCxxDestructCrash: config.fixCxxDestructCrash)
+                                          fixCxxDestructCrash: config.fixCxxDestructCrash,
+                                          useSafeDeleteForNonSQLiteStore: config.useSafeDeleteForNonSQLiteStore)
 
         return CourierClientFactory().makeMQTTClient(config: mqttConfig)
     }


### PR DESCRIPTION
Problem:
On devices where the SQLite message store fails to initialize, the app falls back to an in-memory store. When MQTTCourierClient.destroy() attempts to delete pending messages using NSBatchDeleteRequest, it crashes with NSInternalInconsistencyException: "Unknown command type <NSBatchDeleteRequest>". This is because NSBatch*Request is only supported on SQLite stores, not in-memory stores.

Solution:

Added useSafeDeleteForNonSQLiteStore flag (defaults to true) to IncomingMessagePersistence
Track which store type was actually initialized (resolvedStoreType)
Route deletion based on store type:
SQLite store → use fast NSBatchDeleteRequest (unchanged)
In-memory store → use safe fetch-and-delete loop (works on all store types)
Flag can be set to false to revert to old behavior if needed